### PR TITLE
250 logo 1x keer voorgelezen

### DIFF
--- a/src/lib/organisms/NavPros.svelte
+++ b/src/lib/organisms/NavPros.svelte
@@ -6,10 +6,10 @@
 
 <header>
   <nav>
-    <a class="logo" href="/">
+    <a class="logo" href="/" aria-label="Home – AdConnect logo">
       <picture>
         <source srcset={logowhite} media="(prefers-color-scheme: dark)" />
-        <img src={logo} alt="Logo" loading="lazy" width="200" height="150" />
+        <img src={logo} alt="" loading="lazy" width="200" height="150" />
       </picture>
     </a>
 


### PR DESCRIPTION
## What does this change?

Resolves issue #250 

Ik heb bij het logo de alt leeg gehaald en op de link een aria gebruikt zodat die nu beter het logo voorleest met de screenreader. 

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [X] [Accessibility test]()


## How to review

- Vinden jullie de tekst die er nu word gezegd goed. 
- Word het goed voorgelezen door de screenreader.

## Summary by Sourcery

Verbeteringen:
- Pas de toegankelijkheid van de logo‑link aan door de beschrijvende tekst van de afbeeldings-`alt` te verplaatsen naar een `aria-label` op de omringende `<a>`‑tag, waarbij het `alt`‑attribuut van de afbeelding leeg blijft.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust logo link accessibility by moving the descriptive text from the image alt to an aria-label on the surrounding anchor, leaving the image alt empty.

</details>