### PR TITLE
236 home knop toegevoegd

### DIFF
--- a/src/lib/organisms/NavPros.svelte
+++ b/src/lib/organisms/NavPros.svelte
@@ -20,6 +20,7 @@
         <span></span>
       </summary>
       <ul class="panel">
+        <li><a href="/">Home</a></li>
         <li><a href="/over-ad">Over Ad's</a></li>
         <li><a href="/publicaties">Publicaties</a></li>
         <li><a href="/talent-award">Talent Award</a></li>
@@ -31,6 +32,7 @@
     </details>
 
     <ul class="desktop-nav">
+      <li><a class={$page.url.pathname === '/' ? 'menu-button active' : 'menu-button'} href="/">Home</a></li>
       <li><a class={$page.url.pathname === '/over-ad' ? 'menu-button active' : 'menu-button'} href="/over-ad">Over Ad's</a></li>
       <li><a class={$page.url.pathname === '/publicaties' ? 'menu-button active' : 'menu-button'} href="/publicaties">Publicaties</a></li>
       <li><a class={$page.url.pathname === '/talent-award' ? 'menu-button active' : 'menu-button'} href="/talent-award">Talent Award</a></li>


### PR DESCRIPTION
## What does this change?

Resolves issue #236 

Ik heb een extra kop in de navigatie gezet met als naam home. De home knop staat op mobile en desktop en op desktop heeft die een active state.  



## How Has This Been Tested?

- [X] [Responsive]()


## Images

<img width="1439" height="672" alt="Scherm­afbeelding 2026-02-09 om 15 51 34" src="https://github.com/user-attachments/assets/75765fb1-9078-4e63-ba2f-b0300df142f6" />
<img width="367" height="542" alt="Scherm­afbeelding 2026-02-09 om 15 51 46" src="https://github.com/user-attachments/assets/6201b806-0d5e-4a17-a0ab-01a82eddcce9" />



## How to review

- Vinden jullie de code goed?
- Wat kan er nog aangepast worden?
