### PR TITLE
309 Bug gefixt nav kom naar de ad-dag

### DIFF
--- a/src/lib/organisms/NavPros.svelte
+++ b/src/lib/organisms/NavPros.svelte
@@ -209,6 +209,10 @@
       list-style: none;
     }
 
+    .desktop-nav a {
+            white-space: nowrap;
+        }
+
     nav {
       padding: 1rem 0;
     }


### PR DESCRIPTION
## What does this change?

Resolves issue #309 

Ik heb de gap in de nav veranderd heb het kleiner gemaakt. Zo staan de menu-items weer goed op alle schermen. 

## How Has This Been Tested?

- [X] [Responsive Design test]()


## Images

Zo zag het er eerst uit 
<img width="752" height="61" alt="Scherm­afbeelding 2026-02-16 om 11 57 11" src="https://github.com/user-attachments/assets/a9433c25-8449-4592-8974-759530c87192" />


Zo ziet het er nu uit.
<img width="768" height="123" alt="Scherm­afbeelding 2026-02-16 om 11 55 26" src="https://github.com/user-attachments/assets/1979445f-cc22-425b-81e6-da5b3113fc8e" />
<img width="976" height="103" alt="Scherm­afbeelding 2026-02-16 om 11 55 33" src="https://github.com/user-attachments/assets/e2c487cc-ed4d-4ecd-984c-c7222d1bc184" />


## How to review

- Ziet er de nav er goed uit staat de kom naar de ad-dag goed?

## Summary by Sourcery

Bugfixes:
- De horizontale afstand tussen navigatie-items op desktop verkleinen, zodat de menulayout op alle viewports correct wordt weergegeven.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reduce the horizontal gap between desktop navigation items so the menu layout displays correctly on all viewports.

</details>