### PR TITLE
fix: fixes the darkmode for the login portal.

### DIFF
--- a/src/routes/admin/login/+page.svelte
+++ b/src/routes/admin/login/+page.svelte
@@ -206,6 +206,12 @@
 		margin: 0 0 2rem;
 	}
 
+	@media (prefers-color-scheme: dark) {
+		h1 {
+			color: var(--text-white);
+		}
+	}
+
 	/* Error */
 	.error-message {
 		display: flex;


### PR DESCRIPTION
## What does this change?

This PR fixes the darkmode for the admin login portal, which was still displaying a white background.
Also now uses the correct mascot image with a transparent background.

Resolves issue #365 

## How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

Before: 
<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/b17e6ca1-4374-47e0-a1db-4106339531c0" />

After:
<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/d5fba667-259a-45cf-b12a-dd7cde9267b9" />


## How to review

Boot up the application, navigate to the admin login portal, and verify that the darkmode works as intended with no side effects.