### PR TITLE
fix:#367-Dark-mode iconen zijn aangepast.

### DIFF
--- a/src/lib/molecules/AdminItemCard.svelte
+++ b/src/lib/molecules/AdminItemCard.svelte
@@ -58,7 +58,7 @@
 
 	@media (prefers-color-scheme: dark) {
 		.item-img {
-			filter: brightness(0) saturate(100%) invert(14%) sepia(95%) saturate(6000%) hue-rotate(358deg) brightness(105%) contrast(115%);
+			filter: brightness(0) saturate(100%) invert(30%) sepia(75%) saturate(600%) hue-rotate(322deg) brightness(125%);
 		}
 	}
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #367 

De iconen hebben nu een passende kleur bij de rest van de dark-mode.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<img width="1437" height="439" alt="afbeelding" src="https://github.com/user-attachments/assets/ecf77d99-f6fa-437f-bb92-733a2f76a77a" />


## How to review

-
