### PR TITLE
#276 nieuws formulier

### DIFF
--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -76,7 +76,7 @@
 			<AdminItemCard
 				icon={item.icon}
 				label={item.label}
-				href={item.collection === 'adconnect_documents' ? '/admin/documents/form' : `${directusBase}/${item.collection}/+`}
+				href={item.collection === 'adconnect_documents' ? '/admin/documents/form' : item.collection === 'adconnect_news' ? '/admin/news/form' : `${directusBase}/${item.collection}/+`}
 				iconHeight={item.iconHeight}
 			/>
 		{/each}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -84,9 +84,9 @@
 							? '/admin/themes/form'
 							: item.collection === 'adconnect_faqs'
 								? '/admin/faqs/form'
-                  : item.collection === 'adconnect_news'
-								  ? '/admin/news/form'
-								    : `${directusBase}/${item.collection}/+`}
+								: item.collection === 'adconnect_news'
+									? '/admin/news/form'
+									: `${directusBase}/${item.collection}/+`}
 				iconHeight={item.iconHeight}
 			/>
 		{/each}

--- a/src/routes/admin/news/+page.svelte
+++ b/src/routes/admin/news/+page.svelte
@@ -41,6 +41,7 @@
 	{directusBase}
 	contentType="adconnect_news"
 	breadcrumb="Nieuwsartikelen"
+	addHref="/admin/news/form"
 />
 
 <AdminToolbar

--- a/src/routes/admin/news/form/+page.server.js
+++ b/src/routes/admin/news/form/+page.server.js
@@ -27,6 +27,7 @@ export const actions = {
 		const image = data.get('image')
 		const date = String(data.get('date') ?? '').trim()
 		const author = String(data.get('author') ?? '').trim()
+		const tags = String(data.get('tags') ?? '').trim()
 		const token = cookies.get('access_token')
 
 		if (!token) {
@@ -53,6 +54,10 @@ export const actions = {
 			return fail(400, { error: 'Vul een auteur in.' })
 		}
 
+		if (!tags) {
+			return fail(400, { error: 'Vul tags in.' })
+		}
+
 		const uploadedFileIds = []
 
 		const payload = {
@@ -60,6 +65,7 @@ export const actions = {
 			description,
 			date,
 			author,
+			tags,
 			slug: slugify(title),
 			status: 'draft'
 		}

--- a/src/routes/admin/news/form/+page.server.js
+++ b/src/routes/admin/news/form/+page.server.js
@@ -25,6 +25,7 @@ export const actions = {
 		const title = String(data.get('title') ?? '').trim()
 		const description = String(data.get('description') ?? '').trim()
 		const image = data.get('image')
+		const date = String(data.get('date') ?? '').trim()
 		const token = cookies.get('access_token')
 
 		if (!token) {
@@ -43,11 +44,16 @@ export const actions = {
 			return fail(400, { error: 'Upload een afbeelding.' })
 		}
 
+		if (!date) {
+			return fail(400, { error: 'Vul een datum in.' })
+		}
+
 		const uploadedFileIds = []
 
 		const payload = {
 			title,
 			description,
+			date,
 			slug: slugify(title),
 			status: 'draft'
 		}

--- a/src/routes/admin/news/form/+page.server.js
+++ b/src/routes/admin/news/form/+page.server.js
@@ -1,6 +1,7 @@
 import { ContentService } from '$lib/server/contentService.js'
 import { fail } from '@sveltejs/kit'
 
+const FILE_LIBRARY_FOLDER = 'Adconnect'
 const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het nieuwsartikel.'
 const GENERIC_PUBLISH_WARNING = 'Nieuwsartikel opgeslagen als concept, maar publiceren is mislukt.'
 
@@ -23,6 +24,7 @@ export const actions = {
 		const shouldPublish = submitAction === 'publish'
 		const title = String(data.get('title') ?? '').trim()
 		const description = String(data.get('description') ?? '').trim()
+		const image = data.get('image')
 		const token = cookies.get('access_token')
 
 		if (!token) {
@@ -37,6 +39,12 @@ export const actions = {
 			return fail(400, { error: 'Vul een omschrijving in.' })
 		}
 
+		if (!(image instanceof File) || image.size === 0) {
+			return fail(400, { error: 'Upload een afbeelding.' })
+		}
+
+		const uploadedFileIds = []
+
 		const payload = {
 			title,
 			description,
@@ -47,6 +55,20 @@ export const actions = {
 		let createResult = null
 
 		try {
+			const imageUpload = await ContentService.postFile(image, token, {
+				folderName: FILE_LIBRARY_FOLDER,
+				allowedMimePrefixes: ['image/'],
+				invalidTypeError: 'Afbeelding uploaden mislukt: Bestand is geen afbeelding.'
+			})
+
+			if (!imageUpload?.success) {
+				console.error('[news/form] Image upload failed:', imageUpload)
+				return fail(500, { error: GENERIC_CREATE_ERROR })
+			}
+			uploadedFileIds.push(imageUpload.id)
+
+			payload.hero = imageUpload.id
+
 			createResult = await ContentService.postContent(payload, 'news', token)
 
 			if (!createResult?.success) {
@@ -90,6 +112,15 @@ export const actions = {
 		} catch (err) {
 			console.error('[news/form] Unexpected error during create:', err)
 			return fail(500, { error: GENERIC_CREATE_ERROR })
+		} finally {
+			if (!createResult && uploadedFileIds.length > 0) {
+				for (const fileId of uploadedFileIds) {
+					const result = await ContentService.deleteFile(fileId, token)
+					if (!result?.success) {
+						console.error(`[news/form] Rollback failed for file ${fileId}`)
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/routes/admin/news/form/+page.server.js
+++ b/src/routes/admin/news/form/+page.server.js
@@ -22,6 +22,7 @@ export const actions = {
 		const submitAction = String(data.get('submitAction') ?? 'save').trim()
 		const shouldPublish = submitAction === 'publish'
 		const title = String(data.get('title') ?? '').trim()
+		const description = String(data.get('description') ?? '').trim()
 		const token = cookies.get('access_token')
 
 		if (!token) {
@@ -32,8 +33,13 @@ export const actions = {
 			return fail(400, { error: 'Vul een titel in.' })
 		}
 
+		if (!description) {
+			return fail(400, { error: 'Vul een omschrijving in.' })
+		}
+
 		const payload = {
 			title,
+			description,
 			slug: slugify(title),
 			status: 'draft'
 		}

--- a/src/routes/admin/news/form/+page.server.js
+++ b/src/routes/admin/news/form/+page.server.js
@@ -64,7 +64,7 @@ export const actions = {
 			return fail(400, { error: 'Vul een auteur in.' })
 		}
 
-		if (!tags) {
+		if (tags.length === 0) {
 			return fail(400, { error: 'Vul tags in.' })
 		}
 

--- a/src/routes/admin/news/form/+page.server.js
+++ b/src/routes/admin/news/form/+page.server.js
@@ -1,0 +1,89 @@
+import { ContentService } from '$lib/server/contentService.js'
+import { fail } from '@sveltejs/kit'
+
+const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het nieuwsartikel.'
+const GENERIC_PUBLISH_WARNING = 'Nieuwsartikel opgeslagen als concept, maar publiceren is mislukt.'
+
+// Creates a URL-safe slug from a title string.
+function slugify(value) {
+	return value
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9\s-]/g, '')
+		.replace(/\s+/g, '-')
+		.replace(/-+/g, '-')
+}
+
+export const actions = {
+	// Handles form submission: validates input, creates a news article,
+	// and optionally publishes it.
+	default: async ({ request, cookies }) => {
+		const data = await request.formData()
+		const submitAction = String(data.get('submitAction') ?? 'save').trim()
+		const shouldPublish = submitAction === 'publish'
+		const title = String(data.get('title') ?? '').trim()
+		const token = cookies.get('access_token')
+
+		if (!token) {
+			return fail(403, { error: GENERIC_CREATE_ERROR })
+		}
+
+		if (!title) {
+			return fail(400, { error: 'Vul een titel in.' })
+		}
+
+		const payload = {
+			title,
+			slug: slugify(title),
+			status: 'draft'
+		}
+
+		let createResult = null
+
+		try {
+			createResult = await ContentService.postContent(payload, 'news', token)
+
+			if (!createResult?.success) {
+				console.error('[news/form] News create failed:', createResult)
+				return fail(500, { error: GENERIC_CREATE_ERROR })
+			}
+
+			if (shouldPublish) {
+				try {
+					const publishResult = await ContentService.publishContent(createResult.id, 'news', token)
+
+					if (!publishResult?.success) {
+						console.error('[news/form] Publish failed:', publishResult)
+						return {
+							success: true,
+							message: GENERIC_PUBLISH_WARNING,
+							newsId: createResult.id
+						}
+					}
+				} catch (err) {
+					console.error('[news/form] Unexpected error during publish:', err)
+					return {
+						success: true,
+						message: GENERIC_PUBLISH_WARNING,
+						newsId: createResult.id
+					}
+				}
+
+				return {
+					success: true,
+					message: 'Nieuwsartikel succesvol opgeslagen en gepubliceerd.',
+					newsId: createResult.id
+				}
+			}
+
+			return {
+				success: true,
+				message: 'Nieuwsartikel succesvol opgeslagen als concept.',
+				newsId: createResult.id
+			}
+		} catch (err) {
+			console.error('[news/form] Unexpected error during create:', err)
+			return fail(500, { error: GENERIC_CREATE_ERROR })
+		}
+	}
+}

--- a/src/routes/admin/news/form/+page.server.js
+++ b/src/routes/admin/news/form/+page.server.js
@@ -26,6 +26,7 @@ export const actions = {
 		const description = String(data.get('description') ?? '').trim()
 		const image = data.get('image')
 		const date = String(data.get('date') ?? '').trim()
+		const author = String(data.get('author') ?? '').trim()
 		const token = cookies.get('access_token')
 
 		if (!token) {
@@ -48,12 +49,17 @@ export const actions = {
 			return fail(400, { error: 'Vul een datum in.' })
 		}
 
+		if (!author) {
+			return fail(400, { error: 'Vul een auteur in.' })
+		}
+
 		const uploadedFileIds = []
 
 		const payload = {
 			title,
 			description,
 			date,
+			author,
 			slug: slugify(title),
 			status: 'draft'
 		}

--- a/src/routes/admin/news/form/+page.server.js
+++ b/src/routes/admin/news/form/+page.server.js
@@ -5,18 +5,20 @@ const FILE_LIBRARY_FOLDER = 'Adconnect'
 const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het nieuwsartikel.'
 const GENERIC_PUBLISH_WARNING = 'Nieuwsartikel opgeslagen als concept, maar publiceren is mislukt.'
 
-// Creates a URL-safe slug from a title string.
-function slugify(value) {
-	return value
-		.toLowerCase()
-		.trim()
-		.replace(/[^a-z0-9\s-]/g, '')
-		.replace(/\s+/g, '-')
-		.replace(/-+/g, '-')
+// Deletes uploaded files when news creation fails.
+async function rollbackUploadedFiles(fileIds, accessToken) {
+	for (const fileId of fileIds) {
+		if (!fileId) continue
+
+		const result = await ContentService.deleteFile(fileId, accessToken)
+		if (!result?.success) {
+			console.error(`[news/form] Rollback failed for file ${fileId}`)
+		}
+	}
 }
 
 export const actions = {
-	// Handles form submission: validates input, creates a news article,
+	// Handles form submission: validates input, uploads files, creates a news article,
 	// and optionally publishes it.
 	default: async ({ request, cookies }) => {
 		const data = await request.formData()
@@ -27,7 +29,15 @@ export const actions = {
 		const image = data.get('image')
 		const date = String(data.get('date') ?? '').trim()
 		const author = String(data.get('author') ?? '').trim()
-		const tags = String(data.get('tags') ?? '').trim()
+		const tagsRaw = String(data.get('tags') ?? '').trim()
+		let tags = []
+		try {
+			const parsedTags = JSON.parse(tagsRaw)
+			tags = Array.isArray(parsedTags) ? parsedTags.map((tag) => String(tag).trim()).filter(Boolean) : []
+		} catch {
+			tags = []
+		}
+		const body = String(data.get('body') ?? '').trim()
 		const token = cookies.get('access_token')
 
 		if (!token) {
@@ -58,7 +68,12 @@ export const actions = {
 			return fail(400, { error: 'Vul tags in.' })
 		}
 
+		if (!body) {
+			return fail(400, { error: 'Vul de body in.' })
+		}
+
 		const uploadedFileIds = []
+		let newsCreated = false
 
 		const payload = {
 			title,
@@ -66,7 +81,7 @@ export const actions = {
 			date,
 			author,
 			tags,
-			slug: slugify(title),
+			body,
 			status: 'draft'
 		}
 
@@ -93,6 +108,8 @@ export const actions = {
 				console.error('[news/form] News create failed:', createResult)
 				return fail(500, { error: GENERIC_CREATE_ERROR })
 			}
+
+			newsCreated = true
 
 			if (shouldPublish) {
 				try {
@@ -131,13 +148,8 @@ export const actions = {
 			console.error('[news/form] Unexpected error during create:', err)
 			return fail(500, { error: GENERIC_CREATE_ERROR })
 		} finally {
-			if (!createResult && uploadedFileIds.length > 0) {
-				for (const fileId of uploadedFileIds) {
-					const result = await ContentService.deleteFile(fileId, token)
-					if (!result?.success) {
-						console.error(`[news/form] Rollback failed for file ${fileId}`)
-					}
-				}
+			if (!newsCreated && uploadedFileIds.length > 0) {
+				await rollbackUploadedFiles(uploadedFileIds, token)
 			}
 		}
 	}

--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -104,6 +104,18 @@
 		/>
 	</div>
 
+	<div class="field-group">
+		<label for="tags">Tags</label>
+		<input
+			id="tags"
+			name="tags"
+			type="text"
+			autocomplete="off"
+			placeholder="Voer tags in, gescheiden door komma's"
+			required
+		/>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"

--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -8,9 +8,31 @@
 	const directusBase = `${DIRECTUS_URL}/admin/content`
 
 	let isSubmitting = $state(false)
+	let tags = $state([])
+	let tagInput = $state('')
 
 	function scrollToTop() {
 		window.scrollTo({ top: 0, behavior: 'smooth' })
+	}
+
+	function addTag() {
+		const value = tagInput.trim()
+		if (!value) return
+		if (!tags.includes(value)) {
+			tags = [...tags, value]
+		}
+		tagInput = ''
+	}
+
+	function removeTag(index) {
+		tags = tags.filter((_, i) => i !== index)
+	}
+
+	function onTagKeydown(event) {
+		if (event.key === 'Enter') {
+			event.preventDefault()
+			addTag()
+		}
 	}
 </script>
 
@@ -36,6 +58,7 @@
 
 <form
 	method="POST"
+	enctype="multipart/form-data"
 	class="news-form"
 	use:enhance={() => {
 		isSubmitting = true
@@ -106,14 +129,47 @@
 
 	<div class="field-group">
 		<label for="tags">Tags</label>
+		<div class="tags-input-wrap">
+			{#each tags as tag, index (tag)}
+				<span class="tag-chip">
+					{tag}
+					<button
+						type="button"
+						class="tag-remove"
+						onclick={() => removeTag(index)}
+						aria-label="Verwijder tag {tag}"
+					>
+						×
+					</button>
+				</span>
+			{/each}
+			<input
+				id="tags"
+				type="text"
+				autocomplete="off"
+				placeholder="Voer een tag in en druk Enter"
+				bind:value={tagInput}
+				onkeydown={onTagKeydown}
+			/>
+		</div>
 		<input
-			id="tags"
+			type="hidden"
 			name="tags"
-			type="text"
-			autocomplete="off"
-			placeholder="Voer tags in, gescheiden door komma's"
-			required
+			value={JSON.stringify(tags)}
 		/>
+		{#if tags.length === 0}
+			<p class="field-help">Voeg minimaal 1 tag toe met Enter.</p>
+		{/if}
+	</div>
+
+	<div class="field-group">
+		<label for="body">Body</label>
+		<textarea
+			id="body"
+			name="body"
+			placeholder="Voer de body in"
+			required
+		></textarea>
 	</div>
 
 	<div class="actions">
@@ -168,6 +224,13 @@
 		max-width: 280px;
 	}
 
+	.field-help {
+		font-family: var(--font-body);
+		font-size: 0.9rem;
+		color: var(--neutral-600);
+		margin: 0;
+	}
+
 	label {
 		font-family: var(--font-heading);
 		font-size: 1.15rem;
@@ -188,6 +251,52 @@
 
 	input::placeholder {
 		color: var(--neutral-600);
+	}
+
+	.tags-input-wrap {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.5em;
+		border-radius: 12px;
+		border: 1.5px solid var(--primary-orange);
+		padding: 0.5em;
+		background: light-dark(var(--text-white), hsl(210, 30%, 12%));
+	}
+
+	.tags-input-wrap input {
+		border: none;
+		height: 36px;
+		padding: 0 0.35em;
+		min-width: 220px;
+		flex: 1 1 220px;
+		background: transparent;
+	}
+
+	.tags-input-wrap input:focus {
+		outline: none;
+	}
+
+	.tag-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35em;
+		font-family: var(--font-body);
+		font-size: 0.9rem;
+		padding: 0.25em 0.55em;
+		border-radius: 999px;
+		background: hsl(230, 65%, 64%);
+		color: var(--text-white);
+	}
+
+	.tag-remove {
+		border: none;
+		background: transparent;
+		color: inherit;
+		font-size: 1rem;
+		line-height: 1;
+		cursor: pointer;
+		padding: 0;
 	}
 
 	input[type='file'] {

--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -61,6 +61,16 @@
 		/>
 	</div>
 
+	<div class="field-group">
+		<label for="description">Omschrijving</label>
+		<textarea
+			id="description"
+			name="description"
+			placeholder="Voer een korte omschrijving in"
+			required
+		></textarea>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"
@@ -128,6 +138,22 @@
 	}
 
 	input::placeholder {
+		color: var(--neutral-600);
+	}
+
+	textarea {
+		min-height: 150px;
+		resize: vertical;
+		border-radius: 12px;
+		border: 1.5px solid var(--primary-orange);
+		padding: 0.75em 0.9em;
+		font-family: var(--font-body);
+		font-size: 1rem;
+		background: light-dark(var(--text-white), hsl(210, 30%, 12%));
+		color: light-dark(var(--text-darkblue), var(--text-white));
+	}
+
+	textarea::placeholder {
 		color: var(--neutral-600);
 	}
 

--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -1,0 +1,152 @@
+<script>
+	import { enhance } from '$app/forms'
+	import { DIRECTUS_URL } from '$lib/constants.js'
+	import AdminHeader from '$lib/organisms/AdminHeader.svelte'
+	import Error from '$lib/atoms/Error.svelte'
+
+	const { form } = $props()
+	const directusBase = `${DIRECTUS_URL}/admin/content`
+
+	let isSubmitting = $state(false)
+
+	function scrollToTop() {
+		window.scrollTo({ top: 0, behavior: 'smooth' })
+	}
+</script>
+
+<svelte:head>
+	<title>Nieuwsartikel toevoegen | ADConnect Admin</title>
+</svelte:head>
+
+<AdminHeader
+	title="Nieuwsartikelen"
+	{directusBase}
+	contentType="adconnect_news"
+	breadcrumb="Nieuwsartikelen › Formulier"
+	addHref="/admin/news/form"
+/>
+
+{#if form?.error}
+	<Error message={form.error} />
+{/if}
+
+{#if form?.success && form?.message}
+	<p class="success-message">{form.message}</p>
+{/if}
+
+<form
+	method="POST"
+	class="news-form"
+	use:enhance={() => {
+		isSubmitting = true
+		return async ({ result, update }) => {
+			await update()
+			isSubmitting = false
+
+			if (result.type === 'success') {
+				scrollToTop()
+			}
+		}
+	}}
+>
+	<div class="field-group">
+		<label for="title">Titel</label>
+		<input
+			id="title"
+			name="title"
+			type="text"
+			autocomplete="off"
+			placeholder="Voer een titel in"
+			required
+		/>
+	</div>
+
+	<div class="actions">
+		<button
+			type="submit"
+			name="submitAction"
+			value="save"
+			class="button-outline-blue"
+			disabled={isSubmitting}
+		>
+			{isSubmitting ? 'Opslaan...' : 'Opslaan'}
+		</button>
+		<button
+			type="submit"
+			name="submitAction"
+			value="publish"
+			class="button-outline-blue"
+			disabled={isSubmitting}
+			title="Publiceren"
+		>
+			{isSubmitting ? 'Publiceren...' : 'Publiceer'}
+		</button>
+	</div>
+</form>
+
+<style>
+	.success-message {
+		font-family: var(--font-body);
+		font-size: 0.95rem;
+		background-color: hsl(140, 45%, 18%);
+		color: var(--text-white);
+		border-radius: 10px;
+		padding: 0.7em 1em;
+		margin: 0.75em 0 1em;
+		width: fit-content;
+	}
+
+	.news-form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25em;
+		max-width: 820px;
+	}
+
+	.field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.45em;
+	}
+
+	label {
+		font-family: var(--font-heading);
+		font-size: 1.15rem;
+		line-height: 1.2;
+		font-weight: var(--weight-semibold);
+	}
+
+	input {
+		height: 48px;
+		border-radius: 12px;
+		border: 1.5px solid var(--primary-orange);
+		padding: 0 0.9em;
+		font-family: var(--font-body);
+		font-size: 1rem;
+		background: light-dark(var(--text-white), hsl(210, 30%, 12%));
+		color: light-dark(var(--text-darkblue), var(--text-white));
+	}
+
+	input::placeholder {
+		color: var(--neutral-600);
+	}
+
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.75em;
+		margin-top: 0.5em;
+	}
+
+	button[disabled] {
+		opacity: 0.65;
+		cursor: not-allowed;
+	}
+
+	@media (max-width: 800px) {
+		.actions {
+			justify-content: flex-start;
+			flex-wrap: wrap;
+		}
+	}
+</style>

--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -71,6 +71,17 @@
 		></textarea>
 	</div>
 
+	<div class="field-group">
+		<label for="image">Afbeelding</label>
+		<input
+			id="image"
+			name="image"
+			type="file"
+			accept="image/*"
+			required
+		/>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"
@@ -139,6 +150,23 @@
 
 	input::placeholder {
 		color: var(--neutral-600);
+	}
+
+	input[type='file'] {
+		height: auto;
+		padding: 0.6em 0.75em;
+	}
+
+	input[type='file']::file-selector-button {
+		font-family: var(--font-heading);
+		font-size: 0.9rem;
+		padding: 0.45em 0.9em;
+		margin-right: 0.7em;
+		border-radius: 10px;
+		border: var(--button-outline-border);
+		background: light-dark(var(--text-white), hsl(210, 30%, 16%));
+		color: var(--button-outline-text);
+		cursor: pointer;
 	}
 
 	textarea {

--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -92,6 +92,18 @@
 		/>
 	</div>
 
+	<div class="field-group">
+		<label for="author">Auteur</label>
+		<input
+			id="author"
+			name="author"
+			type="text"
+			autocomplete="off"
+			placeholder="Voer een auteur in"
+			required
+		/>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"

--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -82,6 +82,16 @@
 		/>
 	</div>
 
+	<div class="field-group field-group-half">
+		<label for="date">Datum</label>
+		<input
+			id="date"
+			name="date"
+			type="date"
+			required
+		/>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"
@@ -128,6 +138,10 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.45em;
+	}
+
+	.field-group-half {
+		max-width: 280px;
 	}
 
 	label {

--- a/src/routes/admin/news/form/news.form.svelte.test.js
+++ b/src/routes/admin/news/form/news.form.svelte.test.js
@@ -1,0 +1,530 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ContentService } from '$lib/server/contentService.js'
+import { actions } from './+page.server.js'
+
+vi.mock('$lib/server/contentService.js', () => ({
+	ContentService: {
+		postFile: vi.fn(),
+		postContent: vi.fn(),
+		publishContent: vi.fn(),
+		deleteFile: vi.fn()
+	}
+}))
+
+function createFormData(fields = {}) {
+	const formData = new FormData()
+	for (const [key, value] of Object.entries(fields)) {
+		formData.append(key, value)
+	}
+	return formData
+}
+
+function createValidFormFields(overrides = {}) {
+	return {
+		title: 'Mijn Nieuwsartikel',
+		description: 'Korte beschrijving van het artikel',
+		date: '2026-03-18',
+		author: 'John Doe',
+		tags: JSON.stringify(['tech', 'nieuws']),
+		image: new File(['image-bytes'], 'hero.png', { type: 'image/png' }),
+		body: 'Dit is de volledige inhoud van het nieuwsartikel.',
+		submitAction: 'save',
+		...overrides
+	}
+}
+
+function createActionEvent({ fields = {}, accessToken = 'token-123' } = {}) {
+	return {
+		request: {
+			formData: vi.fn().mockResolvedValue(createFormData(createValidFormFields(fields)))
+		},
+		cookies: {
+			get: vi.fn().mockReturnValue(accessToken)
+		}
+	}
+}
+
+function expectNoMutationCalls() {
+	expect(ContentService.postFile).not.toHaveBeenCalled()
+	expect(ContentService.postContent).not.toHaveBeenCalled()
+	expect(ContentService.publishContent).not.toHaveBeenCalled()
+}
+
+function mockSuccessfulUploadAndCreate({ imageId = 'img-123', newsId = 'news-789' } = {}) {
+	ContentService.postFile.mockResolvedValue({ success: true, id: imageId })
+	ContentService.postContent.mockResolvedValue({ success: true, id: newsId })
+}
+
+describe('admin news form actions.default', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns 403 when access token is missing', async () => {
+		// Arrange: provide valid form values but no access token cookie.
+		// Why: content creation must be blocked for unauthorized requests.
+		const event = createActionEvent({ accessToken: null })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns 403 fail payload with generic create error message.
+		expect(result).toMatchObject({
+			status: 403,
+			data: { error: 'Er is iets misgegaan bij het opslaan van het nieuwsartikel.' }
+		})
+		// Assert: no mutation calls happen when request is unauthorized.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when title is empty after trim', async () => {
+		// Arrange: provide authenticated context but a whitespace-only title.
+		// Why: server-side trim validation should block empty titles.
+		const event = createActionEvent({
+			fields: {
+				title: '   '
+			}
+		})
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the title validation message.
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Vul een titel in.' }
+		})
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when description is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only description.
+		// Why: this isolates the description trim validation from unrelated fields.
+		const event = createActionEvent({
+			fields: {
+				description: '   '
+			}
+		})
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the description validation message.
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Vul een omschrijving in.' }
+		})
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when date is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only date.
+		// Why: this isolates required date validation from unrelated fields.
+		const event = createActionEvent({
+			fields: {
+				date: '   '
+			}
+		})
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the date validation message.
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Vul een datum in.' }
+		})
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when author is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only author.
+		// Why: this isolates required author validation from unrelated fields.
+		const event = createActionEvent({
+			fields: {
+				author: '   '
+			}
+		})
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the author validation message.
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Vul een auteur in.' }
+		})
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when tags is empty after parsing', async () => {
+		// Arrange: start from valid baseline form data and override tags with empty array.
+		// Why: this isolates required tags validation from unrelated fields.
+		const event = createActionEvent({
+			fields: {
+				tags: JSON.stringify([])
+			}
+		})
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the tags validation message.
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Vul tags in.' }
+		})
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when body is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only body.
+		// Why: this isolates required body validation from unrelated fields.
+		const event = createActionEvent({
+			fields: {
+				body: '   '
+			}
+		})
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the body validation message.
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Vul de body in.' }
+		})
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when image file is zero-byte', async () => {
+		// Arrange: start from valid baseline form data and override only image.
+		// Why: zero-byte uploads should be rejected as invalid images.
+		const event = createActionEvent({
+			fields: {
+				image: new File([], 'empty.png', { type: 'image/png' })
+			}
+		})
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the image validation message.
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Upload een afbeelding.' }
+		})
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('saves news article as draft and returns success payload', async () => {
+		// Arrange: provide valid form input for the default save flow.
+		// Why: this is the primary path admins use to create draft news articles.
+		const event = createActionEvent()
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: save flow returns success response for draft creation.
+		expect(result).toEqual({
+			success: true,
+			message: 'Nieuwsartikel succesvol opgeslagen als concept.',
+			newsId: 'news-789'
+		})
+		// Assert: file upload and content creation are executed once.
+		expect(ContentService.postFile).toHaveBeenCalledTimes(1)
+		expect(ContentService.postContent).toHaveBeenCalledTimes(1)
+		// Assert: publish is not called in save mode.
+		expect(ContentService.publishContent).not.toHaveBeenCalled()
+		// Assert: no rollback is needed on successful create.
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('uploads image with expected folder and mime validation options', async () => {
+		// Arrange: provide valid form input and successful service mocks.
+		// Why: image upload must enforce folder placement and image-only MIME guard.
+		const event = createActionEvent()
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: upload call includes strict image upload options.
+		expect(ContentService.postFile).toHaveBeenCalledWith(expect.any(File), 'token-123', {
+			folderName: 'Adconnect',
+			allowedMimePrefixes: ['image/'],
+			invalidTypeError: 'Afbeelding uploaden mislukt: Bestand is geen afbeelding.'
+		})
+	})
+
+	it('sends expected payload to postContent including hero image and draft status', async () => {
+		// Arrange: provide valid form input with parseable tags.
+		// Why: the persisted content contract depends on correct field mapping and draft defaults.
+		const event = createActionEvent({
+			fields: {
+				title: '  Breaking News!!  ',
+				tags: JSON.stringify(['urgent', 'update'])
+			}
+		})
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: content payload includes hero image id, tags array, and draft status.
+		expect(ContentService.postContent).toHaveBeenCalledWith(
+			{
+				title: 'Breaking News!!',
+				description: 'Korte beschrijving van het artikel',
+				date: '2026-03-18',
+				author: 'John Doe',
+				tags: ['urgent', 'update'],
+				body: 'Dit is de volledige inhoud van het nieuwsartikel.',
+				hero: 'img-123',
+				status: 'draft'
+			},
+			'news',
+			'token-123'
+		)
+	})
+
+	it('trims individual tags and filters empty ones from parsed array', async () => {
+		// Arrange: provide tags array with whitespace-padded values.
+		// Why: tags should be trimmed and empty values filtered to prevent duplicate/blank entries.
+		const event = createActionEvent({
+			fields: {
+				tags: JSON.stringify(['  tech  ', '  ', 'news', '   update   '])
+			}
+		})
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: tags are trimmed and blanks filtered.
+		expect(ContentService.postContent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tags: ['tech', 'news', 'update']
+			}),
+			'news',
+			'token-123'
+		)
+	})
+
+	it('handles malformed tags JSON and uses empty array', async () => {
+		// Arrange: provide invalid JSON for tags field with otherwise valid input.
+		// Why: server should gracefully degrade when tags are malformed, not crash.
+		const event = createActionEvent({
+			fields: {
+				tags: 'not-valid-json'
+			}
+		})
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action fails with tags validation error (empty array is invalid).
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Vul tags in.' }
+		})
+	})
+
+	it('publishes created news article when submitAction is publish', async () => {
+		// Arrange: provide valid form input and switch submit action to publish.
+		// Why: publish mode should perform create + publish and return publish success feedback.
+		const event = createActionEvent({
+			fields: {
+				submitAction: 'publish'
+			}
+		})
+		mockSuccessfulUploadAndCreate()
+		ContentService.publishContent.mockResolvedValue({ success: true })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: publish path returns published success message and news id.
+		expect(result).toEqual({
+			success: true,
+			message: 'Nieuwsartikel succesvol opgeslagen en gepubliceerd.',
+			newsId: 'news-789'
+		})
+		// Assert: publish is called with created id, news type, and token.
+		expect(ContentService.publishContent).toHaveBeenCalledWith('news-789', 'news', 'token-123')
+	})
+
+	it('returns warning success payload when publish returns non-success', async () => {
+		// Arrange: create succeeds, but publish returns a non-success result.
+		// Why: flow should keep the created draft and return a warning instead of failing hard.
+		const event = createActionEvent({
+			fields: {
+				submitAction: 'publish'
+			}
+		})
+		mockSuccessfulUploadAndCreate()
+		ContentService.publishContent.mockResolvedValue({ success: false })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: response is success with warning message and created news id.
+		expect(result).toEqual({
+			success: true,
+			message: 'Nieuwsartikel opgeslagen als concept, maar publiceren is mislukt.',
+			newsId: 'news-789'
+		})
+		// Assert: no rollback is triggered because content creation succeeded.
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('returns warning success payload when publish throws an exception', async () => {
+		// Arrange: create succeeds, but publish throws unexpectedly.
+		// Why: publish exceptions should still degrade to a warning while preserving created draft.
+		const event = createActionEvent({
+			fields: {
+				submitAction: 'publish'
+			}
+		})
+		mockSuccessfulUploadAndCreate()
+		ContentService.publishContent.mockRejectedValue(new Error('Publish endpoint timeout'))
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: response is success with warning message and created news id.
+		expect(result).toEqual({
+			success: true,
+			message: 'Nieuwsartikel opgeslagen als concept, maar publiceren is mislukt.',
+			newsId: 'news-789'
+		})
+		// Assert: no rollback is triggered because content creation succeeded.
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('rolls back uploaded image when content creation fails', async () => {
+		// Arrange: image upload succeeds, but content creation fails.
+		// Why: uploaded files must be cleaned up when article creation does not complete.
+		const event = createActionEvent()
+		ContentService.postFile.mockResolvedValue({ success: true, id: 'img-123' })
+		ContentService.postContent.mockResolvedValue({ success: false })
+		ContentService.deleteFile.mockResolvedValue({ success: true })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action fails with generic create error when postContent is unsuccessful.
+		expect(result).toMatchObject({
+			status: 500,
+			data: { error: 'Er is iets misgegaan bij het opslaan van het nieuwsartikel.' }
+		})
+		// Assert: rollback removes the uploaded file id.
+		expect(ContentService.deleteFile).toHaveBeenCalledTimes(1)
+		expect(ContentService.deleteFile).toHaveBeenCalledWith('img-123', 'token-123')
+		// Assert: publish is skipped because content creation failed.
+		expect(ContentService.publishContent).not.toHaveBeenCalled()
+	})
+
+	it('does not rollback files when create flow succeeds without publish', async () => {
+		// Arrange: all operations succeed in save mode (no publish).
+		// Why: successful completion should not trigger cleanup in the finally block.
+		const event = createActionEvent({
+			fields: {
+				submitAction: 'save'
+			}
+		})
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: rollback is never called after successful create (no publish).
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('does not rollback files when publish flow succeeds', async () => {
+		// Arrange: all operations succeed in publish mode.
+		// Why: successful completion should not trigger cleanup in the finally block.
+		const event = createActionEvent({
+			fields: {
+				submitAction: 'publish'
+			}
+		})
+		mockSuccessfulUploadAndCreate()
+		ContentService.publishContent.mockResolvedValue({ success: true })
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: rollback is never called after successful create + publish.
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('treats unknown submitAction as save and skips publish', async () => {
+		// Arrange: provide an unexpected submitAction value with otherwise valid input.
+		// Why: only explicit "publish" should trigger publishing; unknown actions should stay in save flow.
+		const event = createActionEvent({
+			fields: {
+				submitAction: 'archive'
+			}
+		})
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: response follows save mode behavior (draft success message).
+		expect(result).toEqual({
+			success: true,
+			message: 'Nieuwsartikel succesvol opgeslagen als concept.',
+			newsId: 'news-789'
+		})
+		// Assert: publish is not called for unknown submit actions.
+		expect(ContentService.publishContent).not.toHaveBeenCalled()
+	})
+
+	it('returns 500 when image upload fails', async () => {
+		// Arrange: provide valid form input but mock image upload failure.
+		// Why: failed uploads should block article creation with generic error.
+		const event = createActionEvent()
+		ContentService.postFile.mockResolvedValue({ success: false, error: 'Upload failed' })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action fails with generic create error.
+		expect(result).toMatchObject({
+			status: 500,
+			data: { error: 'Er is iets misgegaan bij het opslaan van het nieuwsartikel.' }
+		})
+		// Assert: content create and publish are skipped on failed upload.
+		expect(ContentService.postContent).not.toHaveBeenCalled()
+		expect(ContentService.publishContent).not.toHaveBeenCalled()
+		// Assert: no rollback because upload failed (no file id to clean up).
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('catches unexpected errors during create and returns generic error', async () => {
+		// Arrange: provide valid input and mock unexpected error in postFile.
+		// Why: uncaught exceptions should be caught and returned as generic 500 error.
+		const event = createActionEvent()
+		ContentService.postFile.mockRejectedValue(new Error('Network error'))
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns 500 fail payload with generic error.
+		expect(result).toMatchObject({
+			status: 500,
+			data: { error: 'Er is iets misgegaan bij het opslaan van het nieuwsartikel.' }
+		})
+	})
+})


### PR DESCRIPTION
## What does this change?

Resolves issue #276 

Voegt het formulier toe voor nieuwsartikelen.

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<img width="691" height="885" alt="afbeelding" src="https://github.com/user-attachments/assets/5e5355e1-5668-444c-b79e-9a3f3dce9be6" />


## How to review

1. Ga naar deze branch
2. Ga naar admin dashboard
3. klik op het plus icoontje onder nieuws
4. Vul de benodigde velden in
5. klik op opslaan en of publiceren
6. Check in directus dat deze daadwerkelijk is aangemaakt
