### PR TITLE
#278 events formulier

### DIFF
--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -76,7 +76,21 @@
 			<AdminItemCard
 				icon={item.icon}
 				label={item.label}
-				href={item.collection === 'adconnect_documents' ? '/admin/documents/form' : item.collection === 'adconnect_events' ? '/admin/events/form' : `${directusBase}/${item.collection}/+`}
+				href={item.collection === 'adconnect_documents'
+					? '/admin/documents/form'
+					: item.collection === 'adconnect_nominations'
+						? '/admin/nominations/form'
+						: item.collection === 'adconnect_themes'
+							? '/admin/themes/form'
+							: item.collection === 'adconnect_faqs'
+								? '/admin/faqs/form'
+								: item.collection === 'adconnect_news'
+									? '/admin/news/form'
+									: item.collection === 'adconnect_collaborations'
+										? '/admin/cooperations/form'
+										: item.collection === 'adconnect_events'
+											? '/admin/events/form'
+											: `${directusBase}/${item.collection}/+`}
 				iconHeight={item.iconHeight}
 			/>
 		{/each}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -76,7 +76,7 @@
 			<AdminItemCard
 				icon={item.icon}
 				label={item.label}
-				href={item.collection === 'adconnect_documents' ? '/admin/documents/form' : `${directusBase}/${item.collection}/+`}
+				href={item.collection === 'adconnect_documents' ? '/admin/documents/form' : item.collection === 'adconnect_events' ? '/admin/events/form' : `${directusBase}/${item.collection}/+`}
 				iconHeight={item.iconHeight}
 			/>
 		{/each}

--- a/src/routes/admin/events/+page.svelte
+++ b/src/routes/admin/events/+page.svelte
@@ -41,6 +41,7 @@
 	{directusBase}
 	contentType="adconnect_events"
 	breadcrumb="Events"
+	addHref="/admin/events/form"
 />
 
 <AdminToolbar

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -27,6 +27,7 @@ export const actions = {
 		const title = String(data.get('title') ?? '').trim()
 		const description = String(data.get('description') ?? '').trim()
 		const date = String(data.get('date') ?? '').trim()
+		const excerpt = String(data.get('excerpt') ?? '').trim()
 		const image = data.get('image')
 		const token = cookies.get('access_token')
 
@@ -46,6 +47,10 @@ export const actions = {
 			return fail(400, { error: 'Vul een datum in.' })
 		}
 
+		if (!excerpt) {
+			return fail(400, { error: 'Vul een samenvatting in.' })
+		}
+
 		if (!(image instanceof File) || image.size === 0) {
 			return fail(400, { error: 'Upload een afbeelding.' })
 		}
@@ -57,6 +62,7 @@ export const actions = {
 			title,
 			description,
 			date,
+			excerpt,
 			status: 'draft'
 		}
 

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -12,6 +12,7 @@ export const actions = {
 		const submitAction = String(data.get('submitAction') ?? 'save').trim()
 		const shouldPublish = submitAction === 'publish'
 		const title = String(data.get('title') ?? '').trim()
+		const description = String(data.get('description') ?? '').trim()
 		const token = cookies.get('access_token')
 
 		if (!token) {
@@ -22,8 +23,13 @@ export const actions = {
 			return fail(400, { error: 'Vul een titel in.' })
 		}
 
+		if (!description) {
+			return fail(400, { error: 'Vul een omschrijving in.' })
+		}
+
 		const payload = {
 			title,
+			description,
 			status: 'draft'
 		}
 

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -1,0 +1,76 @@
+import { ContentService } from '$lib/server/contentService.js'
+import { fail } from '@sveltejs/kit'
+
+const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het event.'
+const GENERIC_PUBLISH_WARNING = 'Event opgeslagen als concept, maar publiceren is mislukt.'
+
+export const actions = {
+	// Handles form submission: validates input, creates an event,
+	// and optionally publishes it.
+	default: async ({ request, cookies }) => {
+		const data = await request.formData()
+		const submitAction = String(data.get('submitAction') ?? 'save').trim()
+		const shouldPublish = submitAction === 'publish'
+		const title = String(data.get('title') ?? '').trim()
+		const token = cookies.get('access_token')
+
+		if (!token) {
+			return fail(403, { error: GENERIC_CREATE_ERROR })
+		}
+
+		if (!title) {
+			return fail(400, { error: 'Vul een titel in.' })
+		}
+
+		const payload = {
+			title,
+			status: 'draft'
+		}
+
+		try {
+			const createResult = await ContentService.postContent(payload, 'events', token)
+
+			if (!createResult?.success) {
+				console.error('[events/form] Event create failed:', createResult)
+				return fail(500, { error: GENERIC_CREATE_ERROR })
+			}
+
+			if (shouldPublish) {
+				try {
+					const publishResult = await ContentService.publishContent(createResult.id, 'events', token)
+
+					if (!publishResult?.success) {
+						console.error('[events/form] Publish failed:', publishResult)
+						return {
+							success: true,
+							message: GENERIC_PUBLISH_WARNING,
+							eventId: createResult.id
+						}
+					}
+				} catch (err) {
+					console.error('[events/form] Unexpected error during publish:', err)
+					return {
+						success: true,
+						message: GENERIC_PUBLISH_WARNING,
+						eventId: createResult.id
+					}
+				}
+
+				return {
+					success: true,
+					message: 'Event succesvol opgeslagen en gepubliceerd.',
+					eventId: createResult.id
+				}
+			}
+
+			return {
+				success: true,
+				message: 'Event succesvol opgeslagen als concept.',
+				eventId: createResult.id
+			}
+		} catch (err) {
+			console.error('[events/form] Unexpected error during create:', err)
+			return fail(500, { error: GENERIC_CREATE_ERROR })
+		}
+	}
+}

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -1,8 +1,21 @@
 import { ContentService } from '$lib/server/contentService.js'
 import { fail } from '@sveltejs/kit'
 
+const FILE_LIBRARY_FOLDER = 'Adconnect'
 const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het event.'
 const GENERIC_PUBLISH_WARNING = 'Event opgeslagen als concept, maar publiceren is mislukt.'
+
+// Deletes uploaded files when event creation fails.
+async function rollbackUploadedFiles(fileIds, accessToken) {
+	for (const fileId of fileIds) {
+		if (!fileId) continue
+
+		const result = await ContentService.deleteFile(fileId, accessToken)
+		if (!result?.success) {
+			console.error(`[events/form] Rollback failed for file ${fileId}`)
+		}
+	}
+}
 
 export const actions = {
 	// Handles form submission: validates input, creates an event,
@@ -13,6 +26,7 @@ export const actions = {
 		const shouldPublish = submitAction === 'publish'
 		const title = String(data.get('title') ?? '').trim()
 		const description = String(data.get('description') ?? '').trim()
+		const image = data.get('image')
 		const token = cookies.get('access_token')
 
 		if (!token) {
@@ -27,6 +41,13 @@ export const actions = {
 			return fail(400, { error: 'Vul een omschrijving in.' })
 		}
 
+		if (!(image instanceof File) || image.size === 0) {
+			return fail(400, { error: 'Upload een afbeelding.' })
+		}
+
+		const uploadedFileIds = []
+		let eventCreated = false
+
 		const payload = {
 			title,
 			description,
@@ -34,12 +55,28 @@ export const actions = {
 		}
 
 		try {
+			const imageUpload = await ContentService.postFile(image, token, {
+				folderName: FILE_LIBRARY_FOLDER,
+				allowedMimePrefixes: ['image/'],
+				invalidTypeError: 'Afbeelding uploaden mislukt: Bestand is geen afbeelding.'
+			})
+
+			if (!imageUpload?.success) {
+				console.error('[events/form] Image upload failed:', imageUpload)
+				return fail(500, { error: GENERIC_CREATE_ERROR })
+			}
+			uploadedFileIds.push(imageUpload.id)
+
+			payload.hero = imageUpload.id
+
 			const createResult = await ContentService.postContent(payload, 'events', token)
 
 			if (!createResult?.success) {
 				console.error('[events/form] Event create failed:', createResult)
 				return fail(500, { error: GENERIC_CREATE_ERROR })
 			}
+
+			eventCreated = true
 
 			if (shouldPublish) {
 				try {
@@ -77,6 +114,10 @@ export const actions = {
 		} catch (err) {
 			console.error('[events/form] Unexpected error during create:', err)
 			return fail(500, { error: GENERIC_CREATE_ERROR })
+		} finally {
+			if (!eventCreated && uploadedFileIds.length > 0) {
+				await rollbackUploadedFiles(uploadedFileIds, token)
+			}
 		}
 	}
 }

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -5,6 +5,16 @@ const FILE_LIBRARY_FOLDER = 'Adconnect'
 const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het event.'
 const GENERIC_PUBLISH_WARNING = 'Event opgeslagen als concept, maar publiceren is mislukt.'
 
+// Creates a URL-safe slug from a title string.
+function slugify(value) {
+	return value
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9\s-]/g, '')
+		.replace(/\s+/g, '-')
+		.replace(/-+/g, '-')
+}
+
 // Deletes uploaded files when event creation fails.
 async function rollbackUploadedFiles(fileIds, accessToken) {
 	for (const fileId of fileIds) {
@@ -88,12 +98,15 @@ export const actions = {
 
 		const payload = {
 			title,
+			slug: slugify(title),
 			description,
 			date,
 			time_duration: timeDuration,
 			excerpt,
 			body,
-			nomination_id: [nominationId],
+			nomination_id: {
+				create: [{ adconnect_nominations_id: nominationId }]
+			},
 			status: 'draft'
 		}
 
@@ -116,7 +129,9 @@ export const actions = {
 
 			if (!createResult?.success) {
 				console.error('[events/form] Event create failed:', createResult)
-				return fail(500, { error: GENERIC_CREATE_ERROR })
+				const status = Number(createResult?.status) || 500
+				const errorMessage = createResult?.data?.error ?? GENERIC_CREATE_ERROR
+				return fail(status, { error: errorMessage })
 			}
 
 			eventCreated = true

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -40,6 +40,7 @@ export const actions = {
 		const title = String(data.get('title') ?? '').trim()
 		const description = String(data.get('description') ?? '').trim()
 		const date = String(data.get('date') ?? '').trim()
+		const timeDuration = String(data.get('time_duration') ?? '').trim()
 		const excerpt = String(data.get('excerpt') ?? '').trim()
 		const body = String(data.get('body') ?? '').trim()
 		const nominationId = String(data.get('nomination_id') ?? '').trim()
@@ -60,6 +61,10 @@ export const actions = {
 
 		if (!date) {
 			return fail(400, { error: 'Vul een datum in.' })
+		}
+
+		if (!timeDuration) {
+			return fail(400, { error: 'Vul een tijdsduur in.' })
 		}
 
 		if (!excerpt) {
@@ -85,6 +90,7 @@ export const actions = {
 			title,
 			description,
 			date,
+			time_duration: timeDuration,
 			excerpt,
 			body,
 			nomination_id: [nominationId],

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -17,6 +17,19 @@ async function rollbackUploadedFiles(fileIds, accessToken) {
 	}
 }
 
+// Loads existing nominations so admins can link them to events.
+export async function load({ cookies }) {
+	const { data: content, errors } = await ContentService.fetchContent('nominations', null, null, null, true, cookies.get('access_token'))
+
+	const nominations = content.nominations ? [...content.nominations.values()] : []
+	nominations.sort((a, b) => (a?.title ?? '').localeCompare(b?.title ?? '', 'nl'))
+
+	return {
+		nominations,
+		loadError: errors.length ? 'Nominaties konden niet worden geladen.' : null
+	}
+}
+
 export const actions = {
 	// Handles form submission: validates input, creates an event,
 	// and optionally publishes it.
@@ -29,6 +42,7 @@ export const actions = {
 		const date = String(data.get('date') ?? '').trim()
 		const excerpt = String(data.get('excerpt') ?? '').trim()
 		const body = String(data.get('body') ?? '').trim()
+		const nominationId = String(data.get('nomination_id') ?? '').trim()
 		const image = data.get('image')
 		const token = cookies.get('access_token')
 
@@ -56,6 +70,10 @@ export const actions = {
 			return fail(400, { error: 'Vul de body in.' })
 		}
 
+		if (!nominationId) {
+			return fail(400, { error: 'Kies een nominatie.' })
+		}
+
 		if (!(image instanceof File) || image.size === 0) {
 			return fail(400, { error: 'Upload een afbeelding.' })
 		}
@@ -69,6 +87,7 @@ export const actions = {
 			date,
 			excerpt,
 			body,
+			nomination_id: [nominationId],
 			status: 'draft'
 		}
 

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -53,7 +53,10 @@ export const actions = {
 		const timeDuration = String(data.get('time_duration') ?? '').trim()
 		const excerpt = String(data.get('excerpt') ?? '').trim()
 		const body = String(data.get('body') ?? '').trim()
-		const nominationId = String(data.get('nomination_id') ?? '').trim()
+		const nominationIds = data
+			.getAll('nomination_ids')
+			.map((value) => String(value ?? '').trim())
+			.filter(Boolean)
 		const image = data.get('image')
 		const token = cookies.get('access_token')
 
@@ -85,10 +88,6 @@ export const actions = {
 			return fail(400, { error: 'Vul de body in.' })
 		}
 
-		if (!nominationId) {
-			return fail(400, { error: 'Kies een nominatie.' })
-		}
-
 		if (!(image instanceof File) || image.size === 0) {
 			return fail(400, { error: 'Upload een afbeelding.' })
 		}
@@ -104,10 +103,15 @@ export const actions = {
 			time_duration: timeDuration,
 			excerpt,
 			body,
-			nomination_id: {
-				create: [{ adconnect_nominations_id: nominationId }]
-			},
 			status: 'draft'
+		}
+
+		if (nominationIds.length > 0) {
+			payload.nomination_id = {
+				create: nominationIds.map((nominationId) => ({
+					adconnect_nominations_id: nominationId
+				}))
+			}
 		}
 
 		try {

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -28,6 +28,7 @@ export const actions = {
 		const description = String(data.get('description') ?? '').trim()
 		const date = String(data.get('date') ?? '').trim()
 		const excerpt = String(data.get('excerpt') ?? '').trim()
+		const body = String(data.get('body') ?? '').trim()
 		const image = data.get('image')
 		const token = cookies.get('access_token')
 
@@ -51,6 +52,10 @@ export const actions = {
 			return fail(400, { error: 'Vul een samenvatting in.' })
 		}
 
+		if (!body) {
+			return fail(400, { error: 'Vul de body in.' })
+		}
+
 		if (!(image instanceof File) || image.size === 0) {
 			return fail(400, { error: 'Upload een afbeelding.' })
 		}
@@ -63,6 +68,7 @@ export const actions = {
 			description,
 			date,
 			excerpt,
+			body,
 			status: 'draft'
 		}
 

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -26,6 +26,7 @@ export const actions = {
 		const shouldPublish = submitAction === 'publish'
 		const title = String(data.get('title') ?? '').trim()
 		const description = String(data.get('description') ?? '').trim()
+		const date = String(data.get('date') ?? '').trim()
 		const image = data.get('image')
 		const token = cookies.get('access_token')
 
@@ -41,6 +42,10 @@ export const actions = {
 			return fail(400, { error: 'Vul een omschrijving in.' })
 		}
 
+		if (!date) {
+			return fail(400, { error: 'Vul een datum in.' })
+		}
+
 		if (!(image instanceof File) || image.size === 0) {
 			return fail(400, { error: 'Upload een afbeelding.' })
 		}
@@ -51,6 +56,7 @@ export const actions = {
 		const payload = {
 			title,
 			description,
+			date,
 			status: 'draft'
 		}
 

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -36,6 +36,7 @@
 
 <form
 	method="POST"
+	enctype="multipart/form-data"
 	class="event-form"
 	use:enhance={() => {
 		isSubmitting = true
@@ -69,6 +70,17 @@
 			placeholder="Voer een korte omschrijving in"
 			required
 		></textarea>
+	</div>
+
+	<div class="field-group">
+		<label for="image">Afbeelding</label>
+		<input
+			id="image"
+			name="image"
+			type="file"
+			accept="image/*"
+			required
+		/>
 	</div>
 
 	<div class="actions">
@@ -139,6 +151,23 @@
 
 	input::placeholder {
 		color: var(--neutral-600);
+	}
+
+	input[type='file'] {
+		height: auto;
+		padding: 0.6em 0.75em;
+	}
+
+	input[type='file']::file-selector-button {
+		font-family: var(--font-heading);
+		font-size: 0.9rem;
+		padding: 0.45em 0.9em;
+		margin-right: 0.7em;
+		border-radius: 10px;
+		border: var(--button-outline-border);
+		background: light-dark(var(--text-white), hsl(210, 30%, 16%));
+		color: var(--button-outline-text);
+		cursor: pointer;
 	}
 
 	textarea {

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -4,7 +4,8 @@
 	import AdminHeader from '$lib/organisms/AdminHeader.svelte'
 	import Error from '$lib/atoms/Error.svelte'
 
-	const { form } = $props()
+	const { data, form } = $props()
+	const nominations = $derived(data?.nominations ?? [])
 	const directusBase = `${DIRECTUS_URL}/admin/content`
 
 	let isSubmitting = $state(false)
@@ -28,6 +29,10 @@
 
 {#if form?.error}
 	<Error message={form.error} />
+{/if}
+
+{#if data?.loadError}
+	<Error message={data.loadError} />
 {/if}
 
 {#if form?.success && form?.message}
@@ -113,6 +118,24 @@
 		></textarea>
 	</div>
 
+	<div class="field-group">
+		<p class="field-label">Nominatie</p>
+		{#if nominations.length === 0}
+			<p class="field-help">Geen bestaande nominaties gevonden om te koppelen.</p>
+		{:else}
+			<select
+				id="nomination_id"
+				name="nomination_id"
+				required
+			>
+				<option value="">Kies een nominatie</option>
+				{#each nominations as nomination (nomination.id)}
+					<option value={nomination.id}>{nomination.title ?? `Nominatie ${nomination.id}`}</option>
+				{/each}
+			</select>
+		{/if}
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"
@@ -187,6 +210,17 @@
 		color: var(--neutral-600);
 	}
 
+	select {
+		height: 48px;
+		border-radius: 12px;
+		border: 1.5px solid var(--primary-orange);
+		padding: 0 0.9em;
+		font-family: var(--font-body);
+		font-size: 1rem;
+		background: light-dark(var(--text-white), hsl(210, 30%, 12%));
+		color: light-dark(var(--text-darkblue), var(--text-white));
+	}
+
 	input[type='file'] {
 		height: auto;
 		padding: 0.6em 0.75em;
@@ -218,6 +252,21 @@
 
 	textarea::placeholder {
 		color: var(--neutral-600);
+	}
+
+	.field-help {
+		font-family: var(--font-body);
+		font-size: 0.9rem;
+		color: var(--neutral-600);
+		margin: 0;
+	}
+
+	.field-label {
+		font-family: var(--font-heading);
+		font-size: 1.15rem;
+		line-height: 1.2;
+		font-weight: var(--weight-semibold);
+		margin: 0;
 	}
 
 	.actions {

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -93,6 +93,16 @@
 		/>
 	</div>
 
+	<div class="field-group">
+		<label for="excerpt">Samenvatting</label>
+		<textarea
+			id="excerpt"
+			name="excerpt"
+			placeholder="Voer een samenvatting in"
+			required
+		></textarea>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -61,6 +61,16 @@
 		/>
 	</div>
 
+	<div class="field-group">
+		<label for="description">Omschrijving</label>
+		<textarea
+			id="description"
+			name="description"
+			placeholder="Voer een korte omschrijving in"
+			required
+		></textarea>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"
@@ -128,6 +138,22 @@
 	}
 
 	input::placeholder {
+		color: var(--neutral-600);
+	}
+
+	textarea {
+		min-height: 150px;
+		resize: vertical;
+		border-radius: 12px;
+		border: 1.5px solid var(--primary-orange);
+		padding: 0.75em 0.9em;
+		font-family: var(--font-body);
+		font-size: 1rem;
+		background: light-dark(var(--text-white), hsl(210, 30%, 12%));
+		color: light-dark(var(--text-darkblue), var(--text-white));
+	}
+
+	textarea::placeholder {
 		color: var(--neutral-600);
 	}
 

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -103,6 +103,16 @@
 		></textarea>
 	</div>
 
+	<div class="field-group">
+		<label for="body">Body</label>
+		<textarea
+			id="body"
+			name="body"
+			placeholder="Voer de body in"
+			required
+		></textarea>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -83,6 +83,16 @@
 		/>
 	</div>
 
+	<div class="field-group field-group-half">
+		<label for="date">Datum</label>
+		<input
+			id="date"
+			name="date"
+			type="date"
+			required
+		/>
+	</div>
+
 	<div class="actions">
 		<button
 			type="submit"
@@ -129,6 +139,10 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.45em;
+	}
+
+	.field-group-half {
+		max-width: 280px;
 	}
 
 	label {

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -137,6 +137,7 @@
 			<p class="field-label">Nominaties (optioneel)</p>
 			<a
 				href="/admin/nominations/form"
+				target="_blank"
 				class="add-link"
 			>
 				Nominatie toevoegen
@@ -302,7 +303,7 @@
 	.add-link {
 		font-family: var(--font-body);
 		font-size: 0.95rem;
-		color: var(--text-darkblue);
+		color: var(--reds-600);
 		text-decoration: underline;
 		text-underline-offset: 2px;
 	}

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -98,6 +98,18 @@
 		/>
 	</div>
 
+	<div class="field-group field-group-half">
+		<label for="time_duration">Tijdsduur</label>
+		<input
+			id="time_duration"
+			name="time_duration"
+			type="text"
+			autocomplete="off"
+			placeholder="Bijv. 19:00 - 21:00"
+			required
+		/>
+	</div>
+
 	<div class="field-group">
 		<label for="excerpt">Samenvatting</label>
 		<textarea

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -10,9 +10,7 @@
 
 	let isSubmitting = $state(false)
 	let selectedNominationIds = $state([])
-	const selectedNominationsText = $derived(
-		selectedNominationIds.length === 0 ? 'Kies nominaties' : `${selectedNominationIds.length} geselecteerd`
-	)
+	const selectedNominationsText = $derived(selectedNominationIds.length === 0 ? 'Kies nominaties' : `${selectedNominationIds.length} geselecteerd`)
 
 	function scrollToTop() {
 		window.scrollTo({ top: 0, behavior: 'smooth' })

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -9,6 +9,10 @@
 	const directusBase = `${DIRECTUS_URL}/admin/content`
 
 	let isSubmitting = $state(false)
+	let selectedNominationIds = $state([])
+	const selectedNominationsText = $derived(
+		selectedNominationIds.length === 0 ? 'Kies nominaties' : `${selectedNominationIds.length} geselecteerd`
+	)
 
 	function scrollToTop() {
 		window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -131,20 +135,39 @@
 	</div>
 
 	<div class="field-group">
-		<p class="field-label">Nominatie</p>
+		<div class="field-heading-row">
+			<p class="field-label">Nominaties (optioneel)</p>
+			<a
+				href="/admin/nominations/form"
+				class="add-link"
+			>
+				Nominatie toevoegen
+			</a>
+		</div>
 		{#if nominations.length === 0}
 			<p class="field-help">Geen bestaande nominaties gevonden om te koppelen.</p>
 		{:else}
-			<select
-				id="nomination_id"
-				name="nomination_id"
-				required
-			>
-				<option value="">Kies een nominatie</option>
-				{#each nominations as nomination (nomination.id)}
-					<option value={nomination.id}>{nomination.title ?? `Nominatie ${nomination.id}`}</option>
-				{/each}
-			</select>
+			<details class="checkbox-dropdown">
+				<summary>{selectedNominationsText}</summary>
+				<div class="checkbox-list">
+					{#each nominations as nomination (nomination.id)}
+						<label
+							class="checkbox-item"
+							for={`nomination-${nomination.id}`}
+						>
+							<input
+								id={`nomination-${nomination.id}`}
+								type="checkbox"
+								name="nomination_ids"
+								value={nomination.id}
+								bind:group={selectedNominationIds}
+							/>
+							<span>{nomination.title ?? `Nominatie ${nomination.id}`}</span>
+						</label>
+					{/each}
+				</div>
+			</details>
+			<p class="field-help">Je kunt meerdere nominaties aanvinken, of dit veld leeg laten.</p>
 		{/if}
 	</div>
 
@@ -207,7 +230,7 @@
 		font-weight: var(--weight-semibold);
 	}
 
-	input {
+	input:not([type='checkbox']) {
 		height: 48px;
 		border-radius: 12px;
 		border: 1.5px solid var(--primary-orange);
@@ -218,19 +241,8 @@
 		color: light-dark(var(--text-darkblue), var(--text-white));
 	}
 
-	input::placeholder {
+	input:not([type='checkbox'])::placeholder {
 		color: var(--neutral-600);
-	}
-
-	select {
-		height: 48px;
-		border-radius: 12px;
-		border: 1.5px solid var(--primary-orange);
-		padding: 0 0.9em;
-		font-family: var(--font-body);
-		font-size: 1rem;
-		background: light-dark(var(--text-white), hsl(210, 30%, 12%));
-		color: light-dark(var(--text-darkblue), var(--text-white));
 	}
 
 	input[type='file'] {
@@ -279,6 +291,70 @@
 		line-height: 1.2;
 		font-weight: var(--weight-semibold);
 		margin: 0;
+	}
+
+	.field-heading-row {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1em;
+		flex-wrap: wrap;
+	}
+
+	.add-link {
+		font-family: var(--font-body);
+		font-size: 0.95rem;
+		color: var(--text-darkblue);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	.add-link:hover {
+		color: var(--primary-orange);
+	}
+
+	.checkbox-dropdown {
+		border: 1.5px solid var(--primary-orange);
+		border-radius: 12px;
+		background: light-dark(var(--text-white), hsl(210, 30%, 12%));
+	}
+
+	.checkbox-dropdown summary {
+		list-style: none;
+		cursor: pointer;
+		padding: 0.75em 0.9em;
+		font-family: var(--font-body);
+		font-size: 1rem;
+		color: light-dark(var(--text-darkblue), var(--text-white));
+	}
+
+	.checkbox-dropdown summary::-webkit-details-marker {
+		display: none;
+	}
+
+	.checkbox-list {
+		display: grid;
+		gap: 0.35em;
+		padding: 0 0.8em 0.8em;
+		max-height: 220px;
+		overflow-y: auto;
+	}
+
+	.checkbox-item {
+		display: flex;
+		align-items: center;
+		gap: 0.55em;
+		font-family: var(--font-body);
+		font-size: 0.97rem;
+		font-weight: var(--weight-regular);
+		line-height: 1.35;
+	}
+
+	.checkbox-item input {
+		width: 16px;
+		height: 16px;
+		margin: 0;
+		accent-color: var(--primary-orange);
 	}
 
 	.actions {

--- a/src/routes/admin/events/form/+page.svelte
+++ b/src/routes/admin/events/form/+page.svelte
@@ -1,0 +1,152 @@
+<script>
+	import { enhance } from '$app/forms'
+	import { DIRECTUS_URL } from '$lib/constants.js'
+	import AdminHeader from '$lib/organisms/AdminHeader.svelte'
+	import Error from '$lib/atoms/Error.svelte'
+
+	const { form } = $props()
+	const directusBase = `${DIRECTUS_URL}/admin/content`
+
+	let isSubmitting = $state(false)
+
+	function scrollToTop() {
+		window.scrollTo({ top: 0, behavior: 'smooth' })
+	}
+</script>
+
+<svelte:head>
+	<title>Event toevoegen | ADConnect Admin</title>
+</svelte:head>
+
+<AdminHeader
+	title="Events"
+	{directusBase}
+	contentType="adconnect_events"
+	breadcrumb="Events › Formulier"
+	addHref="/admin/events/form"
+/>
+
+{#if form?.error}
+	<Error message={form.error} />
+{/if}
+
+{#if form?.success && form?.message}
+	<p class="success-message">{form.message}</p>
+{/if}
+
+<form
+	method="POST"
+	class="event-form"
+	use:enhance={() => {
+		isSubmitting = true
+		return async ({ result, update }) => {
+			await update()
+			isSubmitting = false
+
+			if (result.type === 'success') {
+				scrollToTop()
+			}
+		}
+	}}
+>
+	<div class="field-group">
+		<label for="title">Titel</label>
+		<input
+			id="title"
+			name="title"
+			type="text"
+			autocomplete="off"
+			placeholder="Voer een titel in"
+			required
+		/>
+	</div>
+
+	<div class="actions">
+		<button
+			type="submit"
+			name="submitAction"
+			value="save"
+			class="button-outline-blue"
+			disabled={isSubmitting}
+		>
+			{isSubmitting ? 'Opslaan...' : 'Opslaan'}
+		</button>
+		<button
+			type="submit"
+			name="submitAction"
+			value="publish"
+			class="button-outline-blue"
+			disabled={isSubmitting}
+			title="Publiceren"
+		>
+			{isSubmitting ? 'Publiceren...' : 'Publiceer'}
+		</button>
+	</div>
+</form>
+
+<style>
+	.success-message {
+		font-family: var(--font-body);
+		font-size: 0.95rem;
+		background-color: hsl(140, 45%, 18%);
+		color: var(--text-white);
+		border-radius: 10px;
+		padding: 0.7em 1em;
+		margin: 0.75em 0 1em;
+		width: fit-content;
+	}
+
+	.event-form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25em;
+		max-width: 820px;
+	}
+
+	.field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.45em;
+	}
+
+	label {
+		font-family: var(--font-heading);
+		font-size: 1.15rem;
+		line-height: 1.2;
+		font-weight: var(--weight-semibold);
+	}
+
+	input {
+		height: 48px;
+		border-radius: 12px;
+		border: 1.5px solid var(--primary-orange);
+		padding: 0 0.9em;
+		font-family: var(--font-body);
+		font-size: 1rem;
+		background: light-dark(var(--text-white), hsl(210, 30%, 12%));
+		color: light-dark(var(--text-darkblue), var(--text-white));
+	}
+
+	input::placeholder {
+		color: var(--neutral-600);
+	}
+
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.75em;
+		margin-top: 0.5em;
+	}
+
+	button[disabled] {
+		opacity: 0.65;
+		cursor: not-allowed;
+	}
+
+	@media (max-width: 800px) {
+		.actions {
+			justify-content: flex-start;
+			flex-wrap: wrap;
+		}
+	}
+</style>

--- a/src/routes/admin/events/form/event.form.svelte.test.js
+++ b/src/routes/admin/events/form/event.form.svelte.test.js
@@ -1,0 +1,503 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ContentService } from '$lib/server/contentService.js'
+import { actions, load } from './+page.server.js'
+
+vi.mock('$lib/server/contentService.js', () => ({
+	ContentService: {
+		fetchContent: vi.fn(),
+		postFile: vi.fn(),
+		postContent: vi.fn(),
+		publishContent: vi.fn(),
+		deleteFile: vi.fn()
+	}
+}))
+
+function createFormData(fields = {}) {
+	const formData = new FormData()
+	for (const [key, value] of Object.entries(fields)) {
+		formData.append(key, value)
+	}
+	return formData
+}
+
+function createValidFormFields(overrides = {}) {
+	return {
+		title: 'Mijn event',
+		description: 'Korte omschrijving',
+		date: '2026-04-01',
+		time_duration: '19:00 - 21:00',
+		excerpt: 'Korte samenvatting',
+		body: 'Volledige body van het event.',
+		nomination_id: 'nom-1',
+		image: new File(['image-bytes'], 'hero.png', { type: 'image/png' }),
+		submitAction: 'save',
+		...overrides
+	}
+}
+
+function createActionEvent({ fields = {}, accessToken = 'token-123' } = {}) {
+	return {
+		request: {
+			formData: vi.fn().mockResolvedValue(createFormData(createValidFormFields(fields)))
+		},
+		cookies: {
+			get: vi.fn().mockReturnValue(accessToken)
+		}
+	}
+}
+
+function createLoadEvent({ accessToken = 'token-123' } = {}) {
+	return {
+		cookies: {
+			get: vi.fn().mockReturnValue(accessToken)
+		}
+	}
+}
+
+function expectNoMutationCalls() {
+	expect(ContentService.postFile).not.toHaveBeenCalled()
+	expect(ContentService.postContent).not.toHaveBeenCalled()
+	expect(ContentService.publishContent).not.toHaveBeenCalled()
+}
+
+function mockSuccessfulUploadAndCreate({ imageId = 'img-123', eventId = 'evt-789' } = {}) {
+	ContentService.postFile.mockResolvedValue({ success: true, id: imageId })
+	ContentService.postContent.mockResolvedValue({ success: true, id: eventId })
+}
+
+describe('admin events form load', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns nominations sorted by title', async () => {
+		// Arrange: simulate unsorted nomination records from the service.
+		// Why: the nomination dropdown should remain alphabetically stable.
+		ContentService.fetchContent.mockResolvedValue({
+			data: {
+				nominations: new Map([
+					['1', { id: '1', title: 'Zebra' }],
+					['2', { id: '2', title: 'Aap' }],
+					['3', { id: '3', title: 'Mier' }]
+				])
+			},
+			errors: []
+		})
+
+		// Arrange: provide cookie access token as load input context.
+		const event = createLoadEvent()
+
+		// Act: execute the load function.
+		const result = await load(event)
+
+		// Assert: load asks for nominations with the provided token.
+		expect(ContentService.fetchContent).toHaveBeenCalledWith('nominations', null, null, null, true, 'token-123')
+		// Assert: successful fetch should not produce a load error.
+		expect(result.loadError).toBeNull()
+		// Assert: nominations are returned in ascending title order.
+		expect(result.nominations.map((nomination) => nomination.title)).toEqual(['Aap', 'Mier', 'Zebra'])
+	})
+
+	it('returns loadError when nomination fetch has errors', async () => {
+		// Arrange: simulate a fetch response that includes service errors.
+		// Why: the page should surface a fallback warning to admins.
+		ContentService.fetchContent.mockResolvedValue({
+			data: {
+				nominations: new Map([['1', { id: '1', title: 'Kandidaat' }]])
+			},
+			errors: [{ collection: 'nominations', message: 'Network timeout' }]
+		})
+
+		// Arrange: provide cookie access token as load input context.
+		const event = createLoadEvent()
+
+		// Act: execute the load function.
+		const result = await load(event)
+
+		// Assert: nominations still render, and loadError is exposed.
+		expect(result.nominations.map((nomination) => nomination.title)).toEqual(['Kandidaat'])
+		expect(result.loadError).toBe('Nominaties konden niet worden geladen.')
+	})
+
+	it('returns empty nominations when nominations map is missing', async () => {
+		// Arrange: simulate a partial service response without a nominations map.
+		// Why: load should be resilient and avoid crashing on incomplete payloads.
+		ContentService.fetchContent.mockResolvedValue({
+			data: {},
+			errors: []
+		})
+
+		// Arrange: provide cookie access token as load input context.
+		const event = createLoadEvent()
+
+		// Act: execute the load function.
+		const result = await load(event)
+
+		// Assert: nominations fall back to an empty array and no load error is shown.
+		expect(result.nominations).toEqual([])
+		expect(result.loadError).toBeNull()
+	})
+})
+
+describe('admin events form actions.default', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns 403 when access token is missing', async () => {
+		// Arrange: provide valid form values but no access token cookie.
+		// Why: content creation must be blocked for unauthorized requests.
+		const event = createActionEvent({ accessToken: null })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns 403 fail payload with generic create error message.
+		expect(result).toMatchObject({
+			status: 403,
+			data: { error: 'Er is iets misgegaan bij het opslaan van het event.' }
+		})
+		// Assert: no mutation calls happen when request is unauthorized.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when title is empty after trim', async () => {
+		// Arrange: provide authenticated context but a whitespace-only title.
+		// Why: server-side trim validation should block empty titles.
+		const event = createActionEvent({ fields: { title: '   ' } })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the title validation message.
+		expect(result).toMatchObject({ status: 400, data: { error: 'Vul een titel in.' } })
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when description is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only description.
+		// Why: this isolates the description trim validation from unrelated fields.
+		const event = createActionEvent({ fields: { description: '   ' } })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the description validation message.
+		expect(result).toMatchObject({ status: 400, data: { error: 'Vul een omschrijving in.' } })
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when date is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only date.
+		// Why: this isolates required date validation from unrelated fields.
+		const event = createActionEvent({ fields: { date: '   ' } })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the date validation message.
+		expect(result).toMatchObject({ status: 400, data: { error: 'Vul een datum in.' } })
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when time_duration is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only time_duration.
+		// Why: this isolates required duration validation from unrelated fields.
+		const event = createActionEvent({ fields: { time_duration: '   ' } })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the duration validation message.
+		expect(result).toMatchObject({ status: 400, data: { error: 'Vul een tijdsduur in.' } })
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when excerpt is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only excerpt.
+		// Why: this isolates required excerpt validation from unrelated fields.
+		const event = createActionEvent({ fields: { excerpt: '   ' } })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the excerpt validation message.
+		expect(result).toMatchObject({ status: 400, data: { error: 'Vul een samenvatting in.' } })
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when body is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only body.
+		// Why: this isolates required body validation from unrelated fields.
+		const event = createActionEvent({ fields: { body: '   ' } })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with the body validation message.
+		expect(result).toMatchObject({ status: 400, data: { error: 'Vul de body in.' } })
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when nomination_id is empty after trim', async () => {
+		// Arrange: start from valid baseline form data and override only nomination_id.
+		// Why: this isolates required nomination selection validation from unrelated fields.
+		const event = createActionEvent({ fields: { nomination_id: '   ' } })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with nomination validation message.
+		expect(result).toMatchObject({ status: 400, data: { error: 'Kies een nominatie.' } })
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('returns 400 when image file is zero-byte', async () => {
+		// Arrange: start from valid baseline form data and override only image.
+		// Why: zero-byte uploads should be rejected as invalid images.
+		const event = createActionEvent({ fields: { image: new File([], 'empty.png', { type: 'image/png' }) } })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns a 400 fail payload with image validation message.
+		expect(result).toMatchObject({ status: 400, data: { error: 'Upload een afbeelding.' } })
+		// Assert: validation fails before any content mutation calls.
+		expectNoMutationCalls()
+	})
+
+	it('saves event as draft and returns success payload', async () => {
+		// Arrange: provide valid form input for the default save flow.
+		// Why: this is the primary path admins use to create draft events.
+		const event = createActionEvent()
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: save flow returns success response for draft creation.
+		expect(result).toEqual({
+			success: true,
+			message: 'Event succesvol opgeslagen als concept.',
+			eventId: 'evt-789'
+		})
+		// Assert: upload and content creation are executed once.
+		expect(ContentService.postFile).toHaveBeenCalledTimes(1)
+		expect(ContentService.postContent).toHaveBeenCalledTimes(1)
+		// Assert: publish is not called in save mode.
+		expect(ContentService.publishContent).not.toHaveBeenCalled()
+		// Assert: no rollback is needed on successful create.
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('uploads image with expected folder and mime validation options', async () => {
+		// Arrange: provide valid form input and successful service mocks.
+		// Why: image upload must enforce folder placement and image-only MIME guard.
+		const event = createActionEvent()
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: upload call includes strict image upload options.
+		expect(ContentService.postFile).toHaveBeenCalledWith(expect.any(File), 'token-123', {
+			folderName: 'Adconnect',
+			allowedMimePrefixes: ['image/'],
+			invalidTypeError: 'Afbeelding uploaden mislukt: Bestand is geen afbeelding.'
+		})
+	})
+
+	it('sends expected payload to postContent including slug, relation and draft status', async () => {
+		// Arrange: provide valid form input with custom values for assertion clarity.
+		// Why: persisted content contract depends on correct field mapping.
+		const event = createActionEvent({
+			fields: {
+				title: '  Mijn Event!! Titel  ',
+				time_duration: '20:00 - 22:00',
+				nomination_id: 'nom-42'
+			}
+		})
+		mockSuccessfulUploadAndCreate({ imageId: 'img-999' })
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: payload includes mapped hero id, nomination relation and draft status.
+		expect(ContentService.postContent).toHaveBeenCalledWith(
+			{
+				title: 'Mijn Event!! Titel',
+				slug: 'mijn-event-titel',
+				description: 'Korte omschrijving',
+				date: '2026-04-01',
+				time_duration: '20:00 - 22:00',
+				excerpt: 'Korte samenvatting',
+				body: 'Volledige body van het event.',
+				nomination_id: ['nom-42'],
+				status: 'draft',
+				hero: 'img-999'
+			},
+			'events',
+			'token-123'
+		)
+	})
+
+	it('publishes created event when submitAction is publish', async () => {
+		// Arrange: provide valid form input and switch submit action to publish.
+		// Why: publish mode should perform create + publish and return publish success feedback.
+		const event = createActionEvent({ fields: { submitAction: 'publish' } })
+		mockSuccessfulUploadAndCreate()
+		ContentService.publishContent.mockResolvedValue({ success: true })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: publish path returns published success message and event id.
+		expect(result).toEqual({
+			success: true,
+			message: 'Event succesvol opgeslagen en gepubliceerd.',
+			eventId: 'evt-789'
+		})
+		// Assert: publish is called with created id, events type and token.
+		expect(ContentService.publishContent).toHaveBeenCalledWith('evt-789', 'events', 'token-123')
+	})
+
+	it('returns warning success payload when publish returns non-success', async () => {
+		// Arrange: create succeeds, but publish returns a non-success result.
+		// Why: flow should keep the created draft and return a warning instead of failing hard.
+		const event = createActionEvent({ fields: { submitAction: 'publish' } })
+		mockSuccessfulUploadAndCreate()
+		ContentService.publishContent.mockResolvedValue({ success: false })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: response is success with warning message and created event id.
+		expect(result).toEqual({
+			success: true,
+			message: 'Event opgeslagen als concept, maar publiceren is mislukt.',
+			eventId: 'evt-789'
+		})
+		// Assert: no rollback is triggered because content creation succeeded.
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('returns warning success payload when publish throws an exception', async () => {
+		// Arrange: create succeeds, but publish throws unexpectedly.
+		// Why: publish exceptions should still degrade to a warning while preserving created draft.
+		const event = createActionEvent({ fields: { submitAction: 'publish' } })
+		mockSuccessfulUploadAndCreate()
+		ContentService.publishContent.mockRejectedValue(new Error('Publish endpoint timeout'))
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: response is success with warning message and created event id.
+		expect(result).toEqual({
+			success: true,
+			message: 'Event opgeslagen als concept, maar publiceren is mislukt.',
+			eventId: 'evt-789'
+		})
+		// Assert: no rollback is triggered because content creation succeeded.
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('rolls back uploaded image when content creation fails', async () => {
+		// Arrange: image upload succeeds, but content creation fails.
+		// Why: uploaded files must be cleaned up when event creation does not complete.
+		const event = createActionEvent()
+		ContentService.postFile.mockResolvedValue({ success: true, id: 'img-123' })
+		ContentService.postContent.mockResolvedValue({ success: false })
+		ContentService.deleteFile.mockResolvedValue({ success: true })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action fails with generic create error when postContent is unsuccessful.
+		expect(result).toMatchObject({
+			status: 500,
+			data: { error: 'Er is iets misgegaan bij het opslaan van het event.' }
+		})
+		// Assert: rollback removes uploaded file id.
+		expect(ContentService.deleteFile).toHaveBeenCalledTimes(1)
+		expect(ContentService.deleteFile).toHaveBeenCalledWith('img-123', 'token-123')
+		// Assert: publish is skipped because content creation failed.
+		expect(ContentService.publishContent).not.toHaveBeenCalled()
+	})
+
+	it('does not rollback files when publish flow succeeds', async () => {
+		// Arrange: all operations succeed in publish mode.
+		// Why: successful completion should not trigger cleanup in the finally block.
+		const event = createActionEvent({ fields: { submitAction: 'publish' } })
+		mockSuccessfulUploadAndCreate()
+		ContentService.publishContent.mockResolvedValue({ success: true })
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: rollback is never called after successful create + publish.
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('treats unknown submitAction as save and skips publish', async () => {
+		// Arrange: provide an unexpected submitAction value with otherwise valid input.
+		// Why: only explicit "publish" should trigger publishing; unknown actions should stay in save flow.
+		const event = createActionEvent({ fields: { submitAction: 'archive' } })
+		mockSuccessfulUploadAndCreate()
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: response follows save mode behavior (draft success message).
+		expect(result).toEqual({
+			success: true,
+			message: 'Event succesvol opgeslagen als concept.',
+			eventId: 'evt-789'
+		})
+		// Assert: publish is not called for unknown submit actions.
+		expect(ContentService.publishContent).not.toHaveBeenCalled()
+	})
+
+	it('returns 500 when image upload fails', async () => {
+		// Arrange: provide valid form input but mock image upload failure.
+		// Why: failed uploads should block event creation with generic error.
+		const event = createActionEvent()
+		ContentService.postFile.mockResolvedValue({ success: false, error: 'Upload failed' })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action fails with generic create error.
+		expect(result).toMatchObject({
+			status: 500,
+			data: { error: 'Er is iets misgegaan bij het opslaan van het event.' }
+		})
+		// Assert: content create and publish are skipped on failed upload.
+		expect(ContentService.postContent).not.toHaveBeenCalled()
+		expect(ContentService.publishContent).not.toHaveBeenCalled()
+		// Assert: no rollback because upload failed (no file id to clean up).
+		expect(ContentService.deleteFile).not.toHaveBeenCalled()
+	})
+
+	it('catches unexpected errors during create and returns generic error', async () => {
+		// Arrange: provide valid input and mock unexpected error in postFile.
+		// Why: uncaught exceptions should be caught and returned as generic 500 error.
+		const event = createActionEvent()
+		ContentService.postFile.mockRejectedValue(new Error('Network error'))
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action returns 500 fail payload with generic error.
+		expect(result).toMatchObject({
+			status: 500,
+			data: { error: 'Er is iets misgegaan bij het opslaan van het event.' }
+		})
+	})
+})

--- a/src/routes/admin/events/form/event.form.svelte.test.js
+++ b/src/routes/admin/events/form/event.form.svelte.test.js
@@ -15,6 +15,13 @@ vi.mock('$lib/server/contentService.js', () => ({
 function createFormData(fields = {}) {
 	const formData = new FormData()
 	for (const [key, value] of Object.entries(fields)) {
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				formData.append(key, item)
+			}
+			continue
+		}
+
 		formData.append(key, value)
 	}
 	return formData
@@ -28,7 +35,7 @@ function createValidFormFields(overrides = {}) {
 		time_duration: '19:00 - 21:00',
 		excerpt: 'Korte samenvatting',
 		body: 'Volledige body van het event.',
-		nomination_id: 'nom-1',
+		nomination_ids: ['nom-1'],
 		image: new File(['image-bytes'], 'hero.png', { type: 'image/png' }),
 		submitAction: 'save',
 		...overrides
@@ -245,20 +252,6 @@ describe('admin events form actions.default', () => {
 		expectNoMutationCalls()
 	})
 
-	it('returns 400 when nomination_id is empty after trim', async () => {
-		// Arrange: start from valid baseline form data and override only nomination_id.
-		// Why: this isolates required nomination selection validation from unrelated fields.
-		const event = createActionEvent({ fields: { nomination_id: '   ' } })
-
-		// Act: execute the default action.
-		const result = await actions.default(event)
-
-		// Assert: action returns a 400 fail payload with nomination validation message.
-		expect(result).toMatchObject({ status: 400, data: { error: 'Kies een nominatie.' } })
-		// Assert: validation fails before any content mutation calls.
-		expectNoMutationCalls()
-	})
-
 	it('returns 400 when image file is zero-byte', async () => {
 		// Arrange: start from valid baseline form data and override only image.
 		// Why: zero-byte uploads should be rejected as invalid images.
@@ -321,7 +314,7 @@ describe('admin events form actions.default', () => {
 			fields: {
 				title: '  Mijn Event!! Titel  ',
 				time_duration: '20:00 - 22:00',
-				nomination_id: 'nom-42'
+				nomination_ids: ['nom-42', 'nom-43']
 			}
 		})
 		mockSuccessfulUploadAndCreate({ imageId: 'img-999' })
@@ -339,7 +332,39 @@ describe('admin events form actions.default', () => {
 				time_duration: '20:00 - 22:00',
 				excerpt: 'Korte samenvatting',
 				body: 'Volledige body van het event.',
-				nomination_id: ['nom-42'],
+				nomination_id: {
+					create: [
+						{ adconnect_nominations_id: 'nom-42' },
+						{ adconnect_nominations_id: 'nom-43' }
+					]
+				},
+				status: 'draft',
+				hero: 'img-999'
+			},
+			'events',
+			'token-123'
+		)
+	})
+
+	it('omits nomination relation when no nomination is selected', async () => {
+		// Arrange: provide valid form data with an empty checkbox selection list.
+		// Why: nomination linking is optional and event creation should still succeed.
+		const event = createActionEvent({ fields: { nomination_ids: [] } })
+		mockSuccessfulUploadAndCreate({ imageId: 'img-999' })
+
+		// Act: execute the default action.
+		await actions.default(event)
+
+		// Assert: payload excludes nomination relation when no checkbox is checked.
+		expect(ContentService.postContent).toHaveBeenCalledWith(
+			{
+				title: 'Mijn event',
+				slug: 'mijn-event',
+				description: 'Korte omschrijving',
+				date: '2026-04-01',
+				time_duration: '19:00 - 21:00',
+				excerpt: 'Korte samenvatting',
+				body: 'Volledige body van het event.',
 				status: 'draft',
 				hero: 'img-999'
 			},

--- a/src/routes/admin/events/form/event.form.svelte.test.js
+++ b/src/routes/admin/events/form/event.form.svelte.test.js
@@ -333,10 +333,7 @@ describe('admin events form actions.default', () => {
 				excerpt: 'Korte samenvatting',
 				body: 'Volledige body van het event.',
 				nomination_id: {
-					create: [
-						{ adconnect_nominations_id: 'nom-42' },
-						{ adconnect_nominations_id: 'nom-43' }
-					]
+					create: [{ adconnect_nominations_id: 'nom-42' }, { adconnect_nominations_id: 'nom-43' }]
 				},
 				status: 'draft',
 				hero: 'img-999'


### PR DESCRIPTION
## What does this change?

Resolves issue #278 

Voegt een formulier toe, voor het invullen van events.

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Ga naar deze branch
2. Ga naar admin dashboard
3. Klik op het + icoon onder de events bubbel
4. Voeg de benodigde velden in
5. Klik op opslaan.
6. Kijk op directus of deze daadwerkelijk is aangemaakt