### PR TITLE
#470 slugification fix

### DIFF
--- a/src/lib/server/contentService.js
+++ b/src/lib/server/contentService.js
@@ -298,7 +298,16 @@ export class ContentService {
 			})
 
 			if (!res.ok) {
-				return fail(res.status, { error: 'Aanmaken mislukt.' })
+				let parsedError = null
+
+				try {
+					const errorJson = await res.json()
+					parsedError = errorJson?.errors?.[0]?.message ?? errorJson?.error?.message ?? errorJson?.message ?? null
+				} catch {
+					parsedError = null
+				}
+
+				return fail(res.status, { error: parsedError ?? `Aanmaken mislukt (${res.status}).` })
 			}
 
 			const json = await res.json()

--- a/src/lib/server/slugify.js
+++ b/src/lib/server/slugify.js
@@ -1,0 +1,32 @@
+// Class for slugifying strings and handling slug-related errors.
+export class Slugify {
+	// Creates a URL-safe slug from a title string.
+	static slugify(value) {
+		return value
+			.toLowerCase()
+			.trim()
+			.replace(/[^a-z0-9\s-]/g, '')
+			.replace(/\s+/g, '-')
+			.replace(/-+/g, '-')
+	}
+
+	/**
+	 * Checks if an API error is due to a duplicate slug.
+	 * @param {object} result - The API response object to check.
+	 * @returns {boolean} True if the error indicates a duplicate slug, false otherwise.
+	 */
+	static isDuplicateSlugError(result) {
+		const message = String(result?.data?.error ?? '').toLowerCase()
+		return Number(result?.status) === 400 && message.includes('slug') && message.includes('unique')
+	}
+
+	/**
+	 * Generates a unique slug by appending a random suffix.
+	 * @param {string} baseSlug - The base slug to modify.
+	 * @returns {string} The unique slug.
+	 */
+	static slugWithRandomSuffix(baseSlug) {
+		const randomSuffix = Math.floor(Math.random() * 9000) + 1000
+		return `${baseSlug}-${randomSuffix}`
+	}
+}

--- a/src/routes/admin/documents/form/+page.server.js
+++ b/src/routes/admin/documents/form/+page.server.js
@@ -1,19 +1,10 @@
 import { ContentService } from '$lib/server/contentService.js'
 import { fail } from '@sveltejs/kit'
+import { Slugify } from '$lib/server/slugify.js'
 
 const FILE_LIBRARY_FOLDER = 'Adconnect'
 const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het document.'
 const GENERIC_PUBLISH_WARNING = 'Document opgeslagen als concept, maar publiceren is mislukt.'
-
-// Creates a URL-safe slug from a title string.
-function slugify(value) {
-	return value
-		.toLowerCase()
-		.trim()
-		.replace(/[^a-z0-9\s-]/g, '')
-		.replace(/\s+/g, '-')
-		.replace(/-+/g, '-')
-}
 
 // Deletes uploaded files when document creation fails.
 async function rollbackUploadedFiles(fileIds, accessToken) {
@@ -112,22 +103,32 @@ export const actions = {
 			}
 			uploadedFileIds.push(sourceUpload.id)
 
-			const payload = {
+			const baseSlug = Slugify.slugify(title)
+			let payload = {
 				title,
 				description,
 				date,
 				category,
 				hero_image: imageUpload.id,
 				source_file: sourceUpload.id,
-				slug: slugify(title),
+				slug: baseSlug,
 				status: 'draft'
 			}
 
 			createResult = await ContentService.postContent(payload, 'documents', token)
 
+			let retryCount = 0
+			while (!createResult?.success && Slugify.isDuplicateSlugError(createResult) && retryCount < 3) {
+				retryCount += 1
+				payload = { ...payload, slug: Slugify.slugWithRandomSuffix(baseSlug) }
+				createResult = await ContentService.postContent(payload, 'documents', token)
+			}
+
 			if (!createResult?.success) {
 				console.error('[documents/form] Document create failed:', createResult)
-				return fail(500, { error: GENERIC_CREATE_ERROR })
+				const createStatus = Number(createResult?.status) || 500
+				const errorMessage = createResult?.data?.error ?? GENERIC_CREATE_ERROR
+				return fail(createStatus, { error: errorMessage })
 			}
 
 			documentCreated = true

--- a/src/routes/admin/documents/form/document.form.svelte.test.js
+++ b/src/routes/admin/documents/form/document.form.svelte.test.js
@@ -356,6 +356,43 @@ describe('admin documents form actions.default', () => {
 		)
 	})
 
+	it('retries with random slug suffix when slug already exists', async () => {
+		// Arrange: create uses a duplicate slug first, then retries with random suffix.
+		const event = createActionEvent({
+			fields: {
+				title: 'test'
+			}
+		})
+
+		const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.42)
+
+		ContentService.postFile.mockResolvedValueOnce({ success: true, id: 'img-123' }).mockResolvedValueOnce({ success: true, id: 'src-456' })
+		ContentService.postContent
+			.mockResolvedValueOnce({
+				success: false,
+				status: 400,
+				data: {
+					error: 'Aanmaken mislukt: Value "test" for field "slug" in collection "adconnect_documents" has to be unique.'
+				}
+			})
+			.mockResolvedValueOnce({ success: true, id: 'doc-789' })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action retries once with a suffixed slug and succeeds.
+		expect(result).toEqual({
+			success: true,
+			message: 'Document succesvol opgeslagen als concept.',
+			documentId: 'doc-789'
+		})
+		expect(ContentService.postContent).toHaveBeenCalledTimes(2)
+		expect(ContentService.postContent).toHaveBeenNthCalledWith(1, expect.objectContaining({ slug: 'test' }), 'documents', 'token-123')
+		expect(ContentService.postContent).toHaveBeenNthCalledWith(2, expect.objectContaining({ slug: 'test-4780' }), 'documents', 'token-123')
+
+		randomSpy.mockRestore()
+	})
+
 	it('publishes created document when submitAction is publish', async () => {
 		// Arrange: provide valid form input and switch submit action to publish.
 		// Why: publish mode should perform create + publish and return publish success feedback.

--- a/src/routes/admin/events/form/+page.server.js
+++ b/src/routes/admin/events/form/+page.server.js
@@ -1,19 +1,10 @@
 import { ContentService } from '$lib/server/contentService.js'
 import { fail } from '@sveltejs/kit'
+import { Slugify } from '$lib/server/slugify.js'
 
 const FILE_LIBRARY_FOLDER = 'Adconnect'
 const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het event.'
 const GENERIC_PUBLISH_WARNING = 'Event opgeslagen als concept, maar publiceren is mislukt.'
-
-// Creates a URL-safe slug from a title string.
-function slugify(value) {
-	return value
-		.toLowerCase()
-		.trim()
-		.replace(/[^a-z0-9\s-]/g, '')
-		.replace(/\s+/g, '-')
-		.replace(/-+/g, '-')
-}
 
 // Deletes uploaded files when event creation fails.
 async function rollbackUploadedFiles(fileIds, accessToken) {
@@ -95,9 +86,10 @@ export const actions = {
 		const uploadedFileIds = []
 		let eventCreated = false
 
-		const payload = {
+		const baseSlug = Slugify.slugify(title)
+		let payload = {
 			title,
-			slug: slugify(title),
+			slug: baseSlug,
 			description,
 			date,
 			time_duration: timeDuration,
@@ -127,9 +119,16 @@ export const actions = {
 			}
 			uploadedFileIds.push(imageUpload.id)
 
-			payload.hero = imageUpload.id
+			payload = { ...payload, hero: imageUpload.id }
 
-			const createResult = await ContentService.postContent(payload, 'events', token)
+			let createResult = await ContentService.postContent(payload, 'events', token)
+
+			let retryCount = 0
+			while (!createResult?.success && Slugify.isDuplicateSlugError(createResult) && retryCount < 3) {
+				retryCount += 1
+				payload = { ...payload, slug: Slugify.slugWithRandomSuffix(baseSlug) }
+				createResult = await ContentService.postContent(payload, 'events', token)
+			}
 
 			if (!createResult?.success) {
 				console.error('[events/form] Event create failed:', createResult)

--- a/src/routes/admin/events/form/event.form.svelte.test.js
+++ b/src/routes/admin/events/form/event.form.svelte.test.js
@@ -370,6 +370,44 @@ describe('admin events form actions.default', () => {
 		)
 	})
 
+	it('retries with random slug suffix when slug already exists', async () => {
+		// Arrange: initial create returns duplicate slug, second create succeeds.
+		const event = createActionEvent({
+			fields: {
+				title: 'test',
+				nomination_ids: []
+			}
+		})
+
+		const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.42)
+
+		ContentService.postFile.mockResolvedValue({ success: true, id: 'img-123' })
+		ContentService.postContent
+			.mockResolvedValueOnce({
+				success: false,
+				status: 400,
+				data: {
+					error: 'Aanmaken mislukt: Value "test" for field "slug" in collection "adconnect_events" has to be unique.'
+				}
+			})
+			.mockResolvedValueOnce({ success: true, id: 'evt-789' })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action retries once with a suffixed slug and succeeds.
+		expect(result).toEqual({
+			success: true,
+			message: 'Event succesvol opgeslagen als concept.',
+			eventId: 'evt-789'
+		})
+		expect(ContentService.postContent).toHaveBeenCalledTimes(2)
+		expect(ContentService.postContent).toHaveBeenNthCalledWith(1, expect.objectContaining({ slug: 'test' }), 'events', 'token-123')
+		expect(ContentService.postContent).toHaveBeenNthCalledWith(2, expect.objectContaining({ slug: 'test-4780' }), 'events', 'token-123')
+
+		randomSpy.mockRestore()
+	})
+
 	it('publishes created event when submitAction is publish', async () => {
 		// Arrange: provide valid form input and switch submit action to publish.
 		// Why: publish mode should perform create + publish and return publish success feedback.

--- a/src/routes/admin/nominations/form/+page.server.js
+++ b/src/routes/admin/nominations/form/+page.server.js
@@ -1,29 +1,10 @@
 import { ContentService } from '$lib/server/contentService.js'
 import { fail } from '@sveltejs/kit'
+import { Slugify } from '$lib/server/slugify.js'
 
 const FILE_LIBRARY_FOLDER = 'Adconnect'
 const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van de nominatie.'
 const GENERIC_PUBLISH_WARNING = 'Nominatie opgeslagen als concept, maar publiceren is mislukt.'
-
-// Creates a URL-safe slug from a title string.
-function slugify(value) {
-	return value
-		.toLowerCase()
-		.trim()
-		.replace(/[^a-z0-9\s-]/g, '')
-		.replace(/\s+/g, '-')
-		.replace(/-+/g, '-')
-}
-
-function isDuplicateSlugError(result) {
-	const message = String(result?.data?.error ?? '').toLowerCase()
-	return Number(result?.status) === 400 && message.includes('slug') && message.includes('unique')
-}
-
-function slugWithRandomSuffix(baseSlug) {
-	const randomSuffix = Math.floor(Math.random() * 9000) + 1000
-	return `${baseSlug}-${randomSuffix}`
-}
 
 // Deletes uploaded files when nomination creation fails.
 async function rollbackUploadedFiles(fileIds, accessToken) {
@@ -138,7 +119,7 @@ export const actions = {
 			}
 			uploadedFileIds.push(profilePictureUpload.id)
 
-			const baseSlug = slugify(title)
+			const baseSlug = Slugify.slugify(title)
 			let payload = {
 				title,
 				header,
@@ -161,9 +142,9 @@ export const actions = {
 			let createResult = await ContentService.postContent(payload, 'nominations', token)
 
 			let retryCount = 0
-			while (!createResult?.success && isDuplicateSlugError(createResult) && retryCount < 3) {
+			while (!createResult?.success && Slugify.isDuplicateSlugError(createResult) && retryCount < 3) {
 				retryCount += 1
-				payload = { ...payload, slug: slugWithRandomSuffix(baseSlug) }
+				payload = { ...payload, slug: Slugify.slugWithRandomSuffix(baseSlug) }
 				createResult = await ContentService.postContent(payload, 'nominations', token)
 			}
 

--- a/src/routes/admin/themes/form/+page.server.js
+++ b/src/routes/admin/themes/form/+page.server.js
@@ -1,5 +1,6 @@
 import { ContentService } from '$lib/server/contentService.js'
 import { fail } from '@sveltejs/kit'
+import { Slugify } from '$lib/server/slugify.js'
 
 const FILE_LIBRARY_FOLDER = 'Adconnect'
 const GENERIC_CREATE_ERROR = 'Er is iets misgegaan bij het opslaan van het thema.'
@@ -63,12 +64,14 @@ export const actions = {
 		const uploadedFileIds = []
 		let themeCreated = false
 
-		const payload = {
+		const baseSlug = Slugify.slugify(title)
+		let payload = {
 			title,
 			description,
 			date,
 			excerpt,
 			body,
+			slug: baseSlug,
 			status: 'draft'
 		}
 
@@ -87,13 +90,22 @@ export const actions = {
 			}
 			uploadedFileIds.push(imageUpload.id)
 
-			payload.hero = imageUpload.id
+			payload = { ...payload, hero: imageUpload.id }
 
 			createResult = await ContentService.postContent(payload, 'themes', token)
 
+			let retryCount = 0
+			while (!createResult?.success && Slugify.isDuplicateSlugError(createResult) && retryCount < 3) {
+				retryCount += 1
+				payload = { ...payload, slug: Slugify.slugWithRandomSuffix(baseSlug) }
+				createResult = await ContentService.postContent(payload, 'themes', token)
+			}
+
 			if (!createResult?.success) {
 				console.error('[themes/form] Theme create failed:', createResult)
-				return fail(500, { error: GENERIC_CREATE_ERROR })
+				const createStatus = Number(createResult?.status) || 500
+				const errorMessage = createResult?.data?.error ?? GENERIC_CREATE_ERROR
+				return fail(createStatus, { error: errorMessage })
 			}
 
 			themeCreated = true

--- a/src/routes/admin/themes/form/themes.form.svelte.test.js
+++ b/src/routes/admin/themes/form/themes.form.svelte.test.js
@@ -243,7 +243,7 @@ describe('admin themes form actions.default', () => {
 		})
 	})
 
-	it('sends expected payload to postContent including hero and draft status', async () => {
+	it('sends expected payload to postContent including hero, slug and draft status', async () => {
 		// Arrange: provide a title with spaces/symbols to validate trimming.
 		// Why: the persisted content contract depends on correct mapping and draft defaults.
 		const event = createActionEvent({
@@ -265,11 +265,49 @@ describe('admin themes form actions.default', () => {
 				excerpt: 'Korte samenvatting',
 				body: 'Volledige body van het thema.',
 				hero: 'img-123',
+				slug: 'mijn-thema-met-spaties',
 				status: 'draft'
 			},
 			'themes',
 			'token-123'
 		)
+	})
+
+	it('retries with random slug suffix when slug already exists', async () => {
+		// Arrange: initial create returns duplicate slug, second create succeeds.
+		const event = createActionEvent({
+			fields: {
+				title: 'test'
+			}
+		})
+
+		const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.42)
+
+		ContentService.postFile.mockResolvedValue({ success: true, id: 'img-123' })
+		ContentService.postContent
+			.mockResolvedValueOnce({
+				success: false,
+				status: 400,
+				data: {
+					error: 'Aanmaken mislukt: Value "test" for field "slug" in collection "adconnect_themes" has to be unique.'
+				}
+			})
+			.mockResolvedValueOnce({ success: true, id: 'theme-789' })
+
+		// Act: execute the default action.
+		const result = await actions.default(event)
+
+		// Assert: action retries once with a suffixed slug and succeeds.
+		expect(result).toEqual({
+			success: true,
+			message: 'Thema succesvol opgeslagen als concept.',
+			themeId: 'theme-789'
+		})
+		expect(ContentService.postContent).toHaveBeenCalledTimes(2)
+		expect(ContentService.postContent).toHaveBeenNthCalledWith(1, expect.objectContaining({ slug: 'test' }), 'themes', 'token-123')
+		expect(ContentService.postContent).toHaveBeenNthCalledWith(2, expect.objectContaining({ slug: 'test-4780' }), 'themes', 'token-123')
+
+		randomSpy.mockRestore()
 	})
 
 	it('publishes created theme when submitAction is publish', async () => {


### PR DESCRIPTION
## What does this change?

Resolves issue #470 

Dit verandert de aanpak van het aanmaken van slugs. Hiervoor werden slugs gegenereerd vanaf de titel, in lowercase, en in het geval van spaties met - ertussen. 

Dit was een probleem wanneer je exact dezelfde titel zou gebruiken voor twee of meerdere verschillende contents, aangezien de slug uniek moet zijn, gaf deze in dat geval een error. 

Dit is nu gefixt met een alternatieve aanpak,

1. Content wordt aangemaakt met Titel: "Test"
2. Nieuw content wordt aangemaakt met exact dezelfde Titel: "Test"
3. Directus stuurt ons een foutmelding, dat slug uniek moet zijn -> Content kan niet worden aangemaakt.

Fix: 

1. Ons systeem checkt nu wanneer een slug een duplicate is.
2. In het geval dat de slug een duplicate is, wordt er een random nummer aan vastgeplakt, slug wordt dan dus: test-1234.
3. Content wordt correct aangemaakt, want slug is nu uniek

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

Check of daadwerkelijk contenttypes met slugs, dezelfde titel mogen hebben en dus een random nummer genereren aan het contenttype in het geval dat.
