### PR TITLE
#474 tags reset

### DIFF
--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -11,10 +11,17 @@
 	let tags = $state([])
 	let tagInput = $state('')
 
+	/**
+	 * Scrolls the window to the top Used after form submission to show success/error messages without the user having to scroll manually.
+	 */
 	function scrollToTop() {
 		window.scrollTo({ top: 0, behavior: 'smooth' })
 	}
 
+	/**
+	 * Adds the current tagInput value to the tags array if it's not empty and not already in the array, then clears the tagInput.
+	 * Called when the user presses Enter in the tag input field.
+	 */
 	function addTag() {
 		const value = tagInput.trim()
 		if (!value) return
@@ -24,10 +31,19 @@
 		tagInput = ''
 	}
 
+	/**
+	 * Removes a tag from the tags array based on its index. Called when the user clicks the remove button on a tag chip.
+	 * @param {number} index - The index of the tag to remove in the tags array.
+	 */
 	function removeTag(index) {
 		tags = tags.filter((_, i) => i !== index)
 	}
 
+	/**
+	 * Handles the keydown event on the tag input field.
+	 * If the Enter key is pressed, it prevents the default form submission behavior and calls the addTag function to add the current input as a tag.
+	 * @param {KeyboardEvent} event - The keydown event object from the tag input
+	 */
 	function onTagKeydown(event) {
 		if (event.key === 'Enter') {
 			event.preventDefault()
@@ -67,6 +83,8 @@
 			isSubmitting = false
 
 			if (result.type === 'success') {
+				tags = []
+				tagInput = ''
 				scrollToTop()
 			}
 		}

--- a/src/routes/admin/news/form/+page.svelte
+++ b/src/routes/admin/news/form/+page.svelte
@@ -10,6 +10,7 @@
 	let isSubmitting = $state(false)
 	let tags = $state([])
 	let tagInput = $state('')
+	let tagsInputElement = $state()
 
 	/**
 	 * Scrolls the window to the top Used after form submission to show success/error messages without the user having to scroll manually.
@@ -29,6 +30,7 @@
 			tags = [...tags, value]
 		}
 		tagInput = ''
+		syncTagsValidity()
 	}
 
 	/**
@@ -37,6 +39,7 @@
 	 */
 	function removeTag(index) {
 		tags = tags.filter((_, i) => i !== index)
+		syncTagsValidity()
 	}
 
 	/**
@@ -50,6 +53,20 @@
 			addTag()
 		}
 	}
+
+	/**
+	 * Checks the validity of the tags input by ensuring that at least one tag has been added.
+	 * If the tags array is empty, it sets a custom validity message on the tags input element
+	 */
+	function syncTagsValidity() {
+		if (!tagsInputElement) return
+		tagsInputElement.setCustomValidity(tags.length === 0 ? 'Voeg minimaal 1 tag toe met Enter.' : '')
+	}
+
+	$effect(() => {
+		tags
+		syncTagsValidity()
+	})
 </script>
 
 <svelte:head>
@@ -76,7 +93,14 @@
 	method="POST"
 	enctype="multipart/form-data"
 	class="news-form"
-	use:enhance={() => {
+	use:enhance={({ cancel }) => {
+		syncTagsValidity()
+		if (!tagsInputElement?.checkValidity()) {
+			tagsInputElement?.reportValidity()
+			cancel()
+			return
+		}
+
 		isSubmitting = true
 		return async ({ result, update }) => {
 			await update()
@@ -166,6 +190,7 @@
 				type="text"
 				autocomplete="off"
 				placeholder="Voer een tag in en druk Enter"
+				bind:this={tagsInputElement}
 				bind:value={tagInput}
 				onkeydown={onTagKeydown}
 			/>


### PR DESCRIPTION
## What does this change?

Resolves issue #474 

Tags worden op dit moment gerest, wanneer het formulier succesvol wordt opgeslagen/gepubliceerd.
Voegt ook correcte error handling, voor wanneer het tags veld leeg is.

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [X] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<img width="875" height="141" alt="afbeelding" src="https://github.com/user-attachments/assets/02e59da0-bebe-4712-a6a8-a375be409049" />


## How to review

Tags reset:
1. Ga naar deze branch
2. Ga naar admin dashboard
3. Ga naar nieuwsartikel formulier
4. voeg alle velden in
5. Klik op opslaan
6. Verifieer dat het tags veld nu correct reset

Tags foutmelding:
4. Voeg alle velden in behalve tags
5. Verifieer dat het tags veld een correcte foutmelding meegeeft.
