### PR TITLE
fix: #515 preconnect links. (layout)

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,16 @@
 <svelte:head>
   <link rel="icon" href={favicon} />
   <link rel="stylesheet" href="/stylesheet.css"/>
+
+  <!-- Fonts being loaded in -->
+  <link rel="preload" as="font" href="/fonts/Archivo.woff2" type="font/woff2" crossorigin="anonymous"/>
+  <link rel="preload" as="font" href="/fonts/Archivo.woff" type="font/woff" crossorigin="anonymous"/>
+
+  <link rel="preload" as="font" href="/fonts/Archivo Italic.woff2" type="font/woff2" crossorigin="anonymous"/>
+  <link rel="preload" as="font" href="/fonts/Archivo Italic.woff" type="font/woff" crossorigin="anonymous"/>
+
+  <link rel="preload" as="font" href="/fonts/Clash Display Variable.woff2" type="font/woff2" crossorigin="anonymous"/>
+  <link rel="preload" as="font" href="/fonts/Clash Display Variable.woff" type="font/woff" crossorigin="anonymous"/>
 </svelte:head>
 
 {@render children?.()}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,16 +1,12 @@
 <script>
   import favicon from '$lib/assets/favicon-adc.svg'
-
+  
   const { children } = $props()
 </script>
 
 <svelte:head>
   <link rel="icon" href={favicon} />
-  <link 
-    rel="preconnect"
-    as="style" 
-    href="/stylesheet.css" 
-  />
+  <link rel="stylesheet" href="/stylesheet.css"/>
 </svelte:head>
 
 {@render children?.()}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 
 <svelte:head>
   <link rel="icon" href={favicon} />
-  <link rel="stylesheet" href="/stylesheet.css"/>
+  <link rel="preload" as="style" href="/stylesheet.css" type="text/css"/>
 
   <!-- Fonts being loaded in -->
   <link rel="preload" as="font" href="/fonts/Archivo.woff2" type="font/woff2" crossorigin="anonymous"/>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 
 <svelte:head>
   <link rel="icon" href={favicon} />
-  <link rel="preload" as="style" href="/stylesheet.css" type="text/css"/>
+  <link rel="stylesheet" href="/stylesheet.css">
 
   <!-- Fonts being loaded in -->
   <link rel="preload" as="font" href="/fonts/Archivo.woff2" type="font/woff2" crossorigin="anonymous"/>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,11 @@
 
 <svelte:head>
   <link rel="icon" href={favicon} />
-  <link rel="stylesheet" href="/stylesheet.css" />
+  <link 
+    rel="preconnect"
+    as="style" 
+    href="/stylesheet.css" 
+  />
 </svelte:head>
 
 {@render children?.()}


### PR DESCRIPTION
## What does this change?

Resolves issue #1337

To make sure I can test the results I am creating a pull request early on so that I can keep testing and see if it will work. This pull request and issue were made to cut down on the render time.

[Adconnect](https://adconnect.dev.fdnd.nl/)

## How Has This Been Tested?
In issue #515 we have several sources from our tests that confirm this load time. For any further detailed reading about the test see: [ad-dag](https://github.com/fdnd-agency/adconnect/blob/dev/docs/audits/ad-dag.md) and [contact](https://github.com/fdnd-agency/adconnect/blob/dev/docs/audits/contact.md)

- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()

## How to review

Provide your own lighthouse test and see how it loads on your tests.