### PR TITLE
516 change link directory (Layout)

### DIFF
--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -23,7 +23,7 @@
 
 <a
 	class="scroll"
-	href="#"
+	href="/"
 	><img
 		src={icondown}
 		alt=""

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -21,16 +21,18 @@
 	{@render children?.()}
 </main>
 
+<Footer />
+
 <a
 	class="scroll"
-	href="/"
+	href="#"
+	data-sveltekit-replacestate 
 	><img
 		src={icondown}
 		alt=""
 	/><span class="sr-only">Scroll naar boven</span></a
 >
 
-<Footer />
 
 <style>
 	:root {


### PR DESCRIPTION
Due to the tabindex being wrong I changed the directory where the link takes you, so that it wouldn't mess with the natural flow of the website.

## What does this change?

Resolves issue #516 

Due to the link being a "#" it referred to nothing inside the webpage, making it scroll to the top, but the scroll-index not picking up at the beginning of the page. With the addition of now a "/" we can make sure that the scroll-index starts at the top with "ga naar inhoud" a

[Adconnect](https://adconnect.dev.fdnd.nl/)

## How Has This Been Tested?
This has been tested with a simple tab-test. Both @vsheo and me tested it on localhost and inserting just a "/" on the livesite. It both worked.

- [ ] Tabtest

## How to review

Tab through the page and after you click on the 'terug naar boven' link see if you tab to the "terug naar inhoud" link.
