### PR TITLE
fix: #520 Fixed scroll to the top (Publicaties)

### DIFF
--- a/src/routes/(public)/publicaties/+page.svelte
+++ b/src/routes/(public)/publicaties/+page.svelte
@@ -55,6 +55,7 @@
 		<a
 			href="?category=alle-publicaties"
 			class="button-outline-blue {selectedCategory === 'alle-publicaties' ? 'active' : ''}"
+			data-sveltekit-noscroll
 		>
 			Alle publicaties</a
 		>
@@ -62,8 +63,10 @@
 		{#each categories as categorie (categorie.id)}
 			<a
 				href={`?category=${categorie.title.toLowerCase()}`}
-				class="button-outline-blue {selectedCategory.toLowerCase() === categorie.title.toLowerCase() ? 'active' : ''}">{categorie.title}</a
-			>
+				data-sveltekit-noscroll
+				class="button-outline-blue {selectedCategory.toLowerCase() === categorie.title.toLowerCase() ? 'active' : ''}">{categorie.title}
+				
+			</a>
 		{/each}
 	</div>
 </div>


### PR DESCRIPTION
Previous thoughts on how to fix it were actually quite irrelevant when learning that sveltekit not only has data-sveltekit-reload that helped us in #516 but it also has data-sveltekit-noscroll, that helps with links not jumping to the top of the page when being clicked.

## What does this change?

Resolves issue #520 

[Publicaties](http://localhost:5173/publicaties)

## How Has This Been Tested?

- [x] Click test

## How to review

Go to the publications page and click the filters. See if you are being pulled up to the page again or not.
