### PR TITLE
614 feature lado overzicht pagina

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -25,6 +25,8 @@ export { default as AdminStatItem } from './molecules/AdminStatItem.svelte'
 export { default as AdminItemCard } from './molecules/AdminItemCard.svelte'
 export { default as AdminUserMenu } from './molecules/AdminUserMenu.svelte'
 export { default as PreviewBanner } from './molecules/PreviewBanner.svelte'
+export { default as LadoInfoCard } from './molecules/LadoInfoCard.svelte'
+export { default as LadoAccordionItem } from './molecules/LadoAccordionItem.svelte'
 
 // Organisms
 export { default as MultipleFaq } from './organisms/MultipleFaq.svelte'
@@ -53,6 +55,7 @@ export { default as LadosForm } from './organisms/forms/LadosForm.svelte'
 export { default as CourseForm } from './organisms/forms/CourseForm.svelte'
 export { default as SectoralAdvisoryBoardForm } from './organisms/forms/SectoralAdvisoryBoardForm.svelte'
 export { default as PasswordGate } from './organisms/PasswordGate.svelte'
+export { default as LadosOverview } from './organisms/LadosOverview.svelte'
 
 // Templates
 export { default as Development } from './templates/DevelopmentTemplate.svelte'

--- a/src/lib/molecules/LadoAccordionItem.svelte
+++ b/src/lib/molecules/LadoAccordionItem.svelte
@@ -1,0 +1,225 @@
+<script>
+	export let lado = {}
+
+	const contactPersons = Array.isArray(lado.contact_persons) ? lado.contact_persons : []
+	const courses = Array.isArray(lado.courses) ? lado.courses : []
+	const sectoralAdvisoryBoard = typeof lado.sectoral_advisory_board === 'object' ? lado.sectoral_advisory_board : null
+</script>
+
+<article>
+	<details>
+		<summary>
+			<span>{lado.title}</span>
+			<span
+				class="toggle"
+				aria-hidden="true"
+			></span>
+		</summary>
+
+		<div class="content">
+			{#if lado.national_ad_profile}
+				<p><strong>Landelijk Ad-profiel</strong>{lado.national_ad_profile}</p>
+			{/if}
+
+			{#if lado.lado_status}
+				<p><strong>Status</strong>{lado.lado_status}</p>
+			{/if}
+
+			{#if sectoralAdvisoryBoard?.title}
+				<p><strong>Sectoraal adviescollege</strong>{sectoralAdvisoryBoard.title}</p>
+			{/if}
+
+			{#if contactPersons.length}
+				<section aria-label="Contactpersonen">
+					<strong>Contactpersonen</strong>
+					<ul class="chip-list">
+						{#each contactPersons as contactPerson (contactPerson)}
+							<li>{contactPerson}</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
+
+			{#if courses.length}
+				<section aria-label="Gekoppelde opleidingen">
+					<strong>Opleidingen</strong>
+					<ul class="course-list">
+						{#each courses as course (course.id)}
+							<li class="course-card">
+								<span class="course-title">{course.title ?? `Opleiding ${course.id}`}</span>
+								{#if course.cooperations?.length}
+									<span class="cooperation-row">
+										<span>Samenwerking</span>
+										<span class="cooperation-list">
+											{#each course.cooperations as cooperation, index (cooperation.id)}
+												{#if cooperation.url}
+													<a href={cooperation.url}>{cooperation.name}</a>
+												{:else}
+													<span>{cooperation.name}</span>
+												{/if}{#if index < course.cooperations.length - 1},
+												{/if}
+											{/each}
+										</span>
+									</span>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
+		</div>
+	</details>
+</article>
+
+<style>
+	article {
+		--_background: light-dark(var(--text-white), var(--primary-blue));
+		--_border: light-dark(var(--neutral-300), var(--blue-300));
+		--_text: light-dark(var(--blue-900), var(--text-white));
+		--_chip-background: light-dark(var(--blue-100), var(--blue-800));
+		--_content-border: light-dark(var(--blue-150), var(--blue-300));
+
+		align-self: start;
+		background: var(--_background);
+		border: 1px solid var(--_border);
+		border-radius: 0.45em;
+		color: var(--_text);
+	}
+
+	details {
+		padding: 1em 1.25em;
+	}
+
+	summary {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
+		gap: 1em;
+		min-height: 2.25rem;
+		cursor: pointer;
+		list-style: none;
+		font-family: var(--font-heading);
+		font-weight: var(--heading-font-weight);
+		color: var(--_text);
+	}
+
+	summary::-webkit-details-marker {
+		display: none;
+	}
+
+	.toggle {
+		position: relative;
+		width: 2.4rem;
+		height: 2.4rem;
+		border-radius: 0.4em;
+		background: var(--primary-orange);
+	}
+
+	.toggle::before,
+	.toggle::after {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 45%;
+		height: 2px;
+		background: var(--text-white);
+		transform: translate(-50%, -50%);
+	}
+
+	.toggle::after {
+		transform: translate(-50%, -50%) rotate(90deg);
+	}
+
+	details[open] .toggle::after {
+		transform: translate(-50%, -50%) rotate(0deg);
+	}
+
+	.content {
+		display: grid;
+		gap: 1em;
+		padding-top: 1em;
+		border-top: 1px solid var(--_content-border);
+		margin-top: 1em;
+	}
+
+	p {
+		color: var(--_text);
+	}
+
+	p,
+	section {
+		display: grid;
+		gap: 0.35em;
+	}
+
+	strong {
+		font-family: var(--font-heading);
+		font-weight: var(--heading-font-weight);
+	}
+
+	ul {
+		padding: 0;
+		list-style: none;
+	}
+
+	.chip-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5em;
+	}
+
+	.chip-list li {
+		background: var(--_chip-background);
+		border-radius: 999px;
+		padding: 0.35em 0.75em;
+		font-family: var(--font-body);
+		font-size: 0.95rem;
+	}
+
+	.course-list {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+		gap: 0.65em;
+	}
+
+	.course-card {
+		display: grid;
+		gap: 0.35em;
+		align-content: start;
+		background: var(--_chip-background);
+		border-radius: 0.45em;
+		padding: 0.65em 0.8em;
+		font-family: var(--font-body);
+		font-size: 0.95rem;
+		line-height: 1.35;
+	}
+
+	.course-title {
+		font-weight: var(--weight-medium);
+	}
+
+	.cooperation-row {
+		display: grid;
+		gap: 0.1em;
+		font-size: 0.85rem;
+		font-weight: var(--text-font-weight);
+		opacity: 0.85;
+	}
+
+	.cooperation-row > span:first-child {
+		font-size: 0.75rem;
+		font-weight: var(--weight-medium);
+		text-transform: uppercase;
+	}
+
+	.cooperation-list {
+		overflow-wrap: anywhere;
+	}
+
+	a {
+		color: inherit;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.15em;
+	}
+</style>

--- a/src/lib/molecules/LadoInfoCard.svelte
+++ b/src/lib/molecules/LadoInfoCard.svelte
@@ -1,0 +1,97 @@
+<script>
+	export let title = ''
+	export let description = ''
+	export let open = false
+</script>
+
+<article class:open>
+	<details {open}>
+		<summary>
+			<span>{title}</span>
+			<span
+				class="toggle"
+				aria-hidden="true"
+			></span>
+		</summary>
+
+		<p>{description}</p>
+	</details>
+</article>
+
+<style>
+	article {
+		--_background: light-dark(var(--text-white), var(--primary-blue));
+		--_border: light-dark(var(--neutral-300), var(--blue-300));
+		--_title: light-dark(var(--blue-900), var(--text-white));
+		--_text: light-dark(var(--blue-900), var(--text-white));
+		--_accent: var(--primary-orange);
+
+		align-self: start;
+		background: var(--_background);
+		border: 1px solid var(--_border);
+		border-radius: 0.5em;
+		color: var(--_text);
+	}
+
+	article:has(details[open]) {
+		--_border: light-dark(var(--blue-300), var(--blue-150));
+	}
+
+	details {
+		display: flex;
+		flex-direction: column;
+		padding: 1.5em;
+	}
+
+	summary {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
+		gap: 1em;
+		cursor: pointer;
+		list-style: none;
+		font-family: var(--font-heading);
+		font-size: 1.05rem;
+		font-weight: var(--heading-font-weight);
+		line-height: 1.35;
+		color: var(--_title);
+	}
+
+	summary::-webkit-details-marker {
+		display: none;
+	}
+
+	.toggle {
+		position: relative;
+		width: 2.4rem;
+		height: 2.4rem;
+		flex: 0 0 auto;
+		border-radius: 0.4em;
+		background: var(--_accent);
+	}
+
+	.toggle::before,
+	.toggle::after {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 45%;
+		height: 2px;
+		background: var(--text-white);
+		transform: translate(-50%, -50%);
+	}
+
+	.toggle::after {
+		transform: translate(-50%, -50%) rotate(90deg);
+	}
+
+	details[open] .toggle::after {
+		transform: translate(-50%, -50%) rotate(0deg);
+	}
+
+	p {
+		margin-top: 2em;
+		color: var(--_text);
+	}
+</style>

--- a/src/lib/organisms/LadosOverview.svelte
+++ b/src/lib/organisms/LadosOverview.svelte
@@ -1,0 +1,78 @@
+<script>
+	import LadoAccordionItem from '$lib/molecules/LadoAccordionItem.svelte'
+
+	export let lados = []
+</script>
+
+<section
+	class="lados-overview"
+	id="overzicht-lados"
+>
+	<div class="inner-wrapper">
+		<div class="heading-group">
+			<h2>Overzicht LAdO's</h2>
+			<p>Informatie en wijzigingen: Maritiem Muris, contactpersoon LAdO's.</p>
+		</div>
+
+		{#if lados.length}
+			<div class="lados-grid">
+				{#each lados as lado (lado.id)}
+					<LadoAccordionItem {lado} />
+				{/each}
+			</div>
+		{:else}
+			<p class="empty-state">Er zijn nog geen gepubliceerde LAdO's gevonden.</p>
+		{/if}
+	</div>
+</section>
+
+<style>
+	.lados-overview {
+		background: light-dark(var(--text-white), var(--blue-800));
+		color: light-dark(var(--blue-800), var(--text-white));
+		padding: 3em 5% 5em;
+	}
+
+	.inner-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 2em;
+		max-width: 1400px;
+		margin: 0 auto;
+	}
+
+	.heading-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5em;
+	}
+
+	h2,
+	p {
+		color: light-dark(var(--blue-800), var(--text-white));
+	}
+
+	.heading-group p {
+		font-size: var(--p-xs-size);
+	}
+
+	.lados-grid {
+		display: grid;
+		align-items: start;
+		gap: 1em;
+	}
+
+	.empty-state {
+		background: light-dark(var(--text-white), var(--primary-blue));
+		border: 1px solid light-dark(var(--neutral-300), var(--blue-300));
+		border-radius: 0.5em;
+		color: light-dark(var(--blue-900), var(--text-white));
+		padding: 1.25em;
+	}
+
+	@media (min-width: 768px) {
+		.lados-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+</style>

--- a/src/lib/organisms/LadosOverview.svelte
+++ b/src/lib/organisms/LadosOverview.svelte
@@ -11,7 +11,7 @@
 	<div class="inner-wrapper">
 		<div class="heading-group">
 			<h2>Overzicht LAdO's</h2>
-			<p>Informatie en wijzigingen: Maritiem Muris, contactpersoon LAdO's.</p>
+			<p>Informatie en wijzigingen: Mariëtte Muris, contactpersoon LAdO's.</p>
 		</div>
 
 		{#if lados.length}

--- a/src/lib/organisms/NavPros.svelte
+++ b/src/lib/organisms/NavPros.svelte
@@ -1,268 +1,316 @@
 <script>
-  import { logo, logowhite } from '$lib'
+	import { logo, logowhite } from '$lib'
 
-  import { page } from '$app/stores'
+	import { page } from '$app/stores'
 </script>
 
-
 <nav aria-label="Primair">
-  <a class="logo" href="/" aria-label="Home – AdConnect logo">
-    <picture>
-      <source srcset={logowhite} media="(prefers-color-scheme: dark)" />
-      <img src={logo} alt="" loading="lazy" width="200" height="150" />
-    </picture>
-  </a>
+	<a
+		class="logo"
+		href="/"
+		aria-label="Home – AdConnect logo"
+	>
+		<picture>
+			<source
+				srcset={logowhite}
+				media="(prefers-color-scheme: dark)"
+			/>
+			<img
+				src={logo}
+				alt=""
+				loading="lazy"
+				width="200"
+				height="150"
+			/>
+		</picture>
+	</a>
 
-  <details class="menu">
-    <summary>
-      <span></span>
-      <span></span>
-      <span></span>
-    </summary>
-    <ul class="panel">
-      <li><a href="/">Home</a></li>
-      <li><a href="/over-ad">Over Ad's</a></li>
-      <li><a href="/publicaties">Publicaties</a></li>
-      <li><a href="/talent-award">Talent Award</a></li>
-      <li><a href="/nieuws">Nieuws</a></li>
-      <li><a href="/ad-dag">Ad-dag</a></li>
-      <li><a href="over-ons">Over ons</a></li>
-      <li><a href="/contact">Contact</a></li>
-    </ul>
-  </details>
+	<details class="menu">
+		<summary>
+			<span></span>
+			<span></span>
+			<span></span>
+		</summary>
+		<ul class="panel">
+			<li><a href="/">Home</a></li>
+			<li><a href="/over-ad">Over Ad's</a></li>
+			<li><a href="/lados-en-ad-profielen">LAdO's en Ad-profielen</a></li>
+			<li><a href="/publicaties">Publicaties</a></li>
+			<li><a href="/talent-award">Talent Award</a></li>
+			<li><a href="/nieuws">Nieuws</a></li>
+			<li><a href="/ad-dag">Ad-dag</a></li>
+			<li><a href="over-ons">Over ons</a></li>
+			<li><a href="/contact">Contact</a></li>
+		</ul>
+	</details>
 
-  <ul class="desktop-nav">
-    <li><a class={$page.url.pathname === '/' ? 'menu-button active' : 'menu-button'} href="/">Home</a></li>
-    <li><a class={$page.url.pathname === '/over-ad' ? 'menu-button active' : 'menu-button'} href="/over-ad">Over Ad's</a></li>
-    <li><a class={$page.url.pathname === '/publicaties' ? 'menu-button active' : 'menu-button'} href="/publicaties">Publicaties</a></li>
-    <li><a class={$page.url.pathname === '/talent-award' ? 'menu-button active' : 'menu-button'} href="/talent-award">Talent Award</a></li>
-    <li><a class={$page.url.pathname === '/nieuws' ? 'menu-button active' : 'menu-button'} href="/nieuws">Nieuws</a></li>
-    <li><a class="button-outline-white" href="/ad-dag">Kom naar Ad-dag</a></li>
-  </ul>
+	<ul class="desktop-nav">
+		<li>
+			<a
+				class={$page.url.pathname === '/' ? 'menu-button active' : 'menu-button'}
+				href="/">Home</a
+			>
+		</li>
+		<li>
+			<a
+				class={$page.url.pathname === '/over-ad' ? 'menu-button active' : 'menu-button'}
+				href="/over-ad">Over Ad's</a
+			>
+		</li>
+		<li>
+			<a
+				class={$page.url.pathname === '/lados-en-ad-profielen' ? 'menu-button active' : 'menu-button'}
+				href="/lados-en-ad-profielen">LAdO's en Ad-profielen</a
+			>
+		</li>
+		<li>
+			<a
+				class={$page.url.pathname === '/publicaties' ? 'menu-button active' : 'menu-button'}
+				href="/publicaties">Publicaties</a
+			>
+		</li>
+		<li>
+			<a
+				class={$page.url.pathname === '/talent-award' ? 'menu-button active' : 'menu-button'}
+				href="/talent-award">Talent Award</a
+			>
+		</li>
+		<li>
+			<a
+				class={$page.url.pathname === '/nieuws' ? 'menu-button active' : 'menu-button'}
+				href="/nieuws">Nieuws</a
+			>
+		</li>
+		<li>
+			<a
+				class="button-outline-white"
+				href="/ad-dag">Kom naar Ad-dag</a
+			>
+		</li>
+	</ul>
 </nav>
 
-
 <style>
-  /* MOBILE*/
-  nav {
-    display: flex;
-    position: relative;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    background: var(--background);
-    z-index: 99;
-    box-sizing: border-box;
+	/* MOBILE*/
+	nav {
+		display: flex;
+		position: relative;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		background: var(--background);
+		z-index: 99;
+		box-sizing: border-box;
 
-    position: fixed;
-    top: 2.8em;
-    padding: 1em 5%;
+		position: fixed;
+		top: 2.8em;
+		padding: 1em 5%;
 
-    .logo img {
-      height: 50px;
-    }
-  }
+		.logo img {
+			height: 50px;
+		}
+	}
 
-  summary {
-    display: inline-block;
-    position: relative;
-    cursor: pointer;
-    list-style: none;
-    -webkit-tap-highlight-color: transparent;
-  }
+	summary {
+		display: inline-block;
+		position: relative;
+		cursor: pointer;
+		list-style: none;
+		-webkit-tap-highlight-color: transparent;
+	}
 
-  summary::-webkit-details-marker {
-    display: none;
-  }
+	summary::-webkit-details-marker {
+		display: none;
+	}
 
-  summary span {
-    display: block;
-    position: relative;
-    width: 28px;
-    height: 3px;
-    margin: 6px 0;
-    background: light-dark(var(--blue-800), var(--blue-150));
-    border-radius: 2px;
-    transform-origin: center;
-    transition: all 0.3s ease;
-  }
+	summary span {
+		display: block;
+		position: relative;
+		width: 28px;
+		height: 3px;
+		margin: 6px 0;
+		background: light-dark(var(--blue-800), var(--blue-150));
+		border-radius: 2px;
+		transform-origin: center;
+		transition: all 0.3s ease;
+	}
 
-  .menu {
-    display: block;
-    position: relative;
-    z-index: 0;
-  }
-  .menu:hover summary span {
-    width: 32px;
-  }
+	.menu {
+		display: block;
+		position: relative;
+		z-index: 0;
+	}
+	.menu:hover summary span {
+		width: 32px;
+	}
 
-  .menu::before {
-    content: "";
-    display: block;
-    position: fixed;
-    inset: 0;
-    z-index: 999;
-    background: rgba(0, 0, 0, 0);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.3s ease;
-  }
+	.menu::before {
+		content: '';
+		display: block;
+		position: fixed;
+		inset: 0;
+		z-index: 999;
+		background: rgba(0, 0, 0, 0);
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.3s ease;
+	}
 
-  .menu[open]::before {
-    background: rgba(0, 0, 0, 0.25);
-    opacity: 1;
-    pointer-events: auto;
-  }
+	.menu[open]::before {
+		background: rgba(0, 0, 0, 0.25);
+		opacity: 1;
+		pointer-events: auto;
+	}
 
-  .panel {
-    display: flex;
-    position: fixed;
-    inset: 0;
-    z-index: 1000;
-    flex-direction: column;
-    justify-content: center;
-    gap: 1.2rem;
-    width: 100vw;
-    height: 100vh;
-    margin: 0;
-    padding: clamp(1rem, 3vw, 2rem);
-    box-sizing: border-box;
-    background: var(--background);
-    list-style: none;
-    text-align: left;
-    transform: translateX(100%);
-    transition: transform 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
-    will-change: transform;
-  }
+	.panel {
+		display: flex;
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		flex-direction: column;
+		justify-content: center;
+		gap: 1.2rem;
+		width: 100vw;
+		height: 100vh;
+		margin: 0;
+		padding: clamp(1rem, 3vw, 2rem);
+		box-sizing: border-box;
+		background: var(--background);
+		list-style: none;
+		text-align: left;
+		transform: translateX(100%);
+		transition: transform 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
+		will-change: transform;
+	}
 
-  .menu[open] .panel {
-    transform: translateX(0);
-  }
-  .menu[open] summary {
-    display: inline-block;
-    position: fixed;
-    top: 16px;
-    right: 16px;
-    z-index: 1001;
-    padding: 6px;
-    background: transparent;
-    border-radius: 8px;
-  }
+	.menu[open] .panel {
+		transform: translateX(0);
+	}
+	.menu[open] summary {
+		display: inline-block;
+		position: fixed;
+		top: 16px;
+		right: 16px;
+		z-index: 1001;
+		padding: 6px;
+		background: transparent;
+		border-radius: 8px;
+	}
 
-  .menu[open] summary span:nth-child(1) {
-    transform: translateY(9px) rotate(45deg);
-  }
-  .menu[open] summary span:nth-child(2) {
-    transform: scaleX(0);
-    opacity: 0;
-  }
-  .menu[open] summary span:nth-child(3) {
-    transform: translateY(-9px) rotate(-45deg);
-  }
-  .panel a {
-    display: block;
-    color: light-dark(var(--blue-800), var(--blue-150));
-    font-weight: 500;
-    font-size: 1.2rem;
-    text-decoration: none;
-    padding: 0.5rem 1rem;
-  }
+	.menu[open] summary span:nth-child(1) {
+		transform: translateY(9px) rotate(45deg);
+	}
+	.menu[open] summary span:nth-child(2) {
+		transform: scaleX(0);
+		opacity: 0;
+	}
+	.menu[open] summary span:nth-child(3) {
+		transform: translateY(-9px) rotate(-45deg);
+	}
+	.panel a {
+		display: block;
+		color: light-dark(var(--blue-800), var(--blue-150));
+		font-weight: 500;
+		font-size: 1.2rem;
+		text-decoration: none;
+		padding: 0.5rem 1rem;
+	}
 
-  :global(body:has(.menu[open])) {
-    overflow: hidden;
-  }
+	:global(body:has(.menu[open])) {
+		overflow: hidden;
+	}
 
-  .desktop-nav {
-    display: none;
-  }
+	.desktop-nav {
+		display: none;
+	}
 
-  /* Desktop */
-  @media (min-width: 1160px) {
-    nav {
-      padding: 1em 5%;
-    }
+	/* Desktop */
+	@media (min-width: 1160px) {
+		nav {
+			padding: 1em 5%;
+		}
 
-    .logo {
-      display: block;
-      height: 50px;
-    }
+		.logo {
+			display: block;
+			height: 50px;
+		}
 
-    .logo img {
-      width: 12em;
-    }
+		.logo img {
+			width: 12em;
+		}
 
-    .menu {
-      display: none;
-    }
+		.menu {
+			display: none;
+		}
 
-    .desktop-nav {
-      display: flex;
-      position: relative;
-      gap: 1.5rem;
-      list-style: none;
-    }
+		.desktop-nav {
+			display: flex;
+			position: relative;
+			gap: 1.5rem;
+			list-style: none;
+		}
 
-    .desktop-nav a {
-            white-space: nowrap;
-        }
+		.desktop-nav a {
+			white-space: nowrap;
+		}
 
-    /* Hover animatie menu items */
-    .menu-button {
-      font-weight: var(--heading-font-weight);
-      color: light-dark(var(--blue-800), var(--blue-150));
-      padding: 0.5rem 1rem;
-    }
-  }
+		/* Hover animatie menu items */
+		.menu-button {
+			font-weight: var(--heading-font-weight);
+			color: light-dark(var(--blue-800), var(--blue-150));
+			padding: 0.5rem 1rem;
+		}
+	}
 
-  .menu-button:hover::after {
-    width: 100%;
-  }
+	.menu-button:hover::after {
+		width: 100%;
+	}
 
-  /* Accessibility */
-  @media (prefers-reduced-motion: reduce) {
-    .panel,
-    .menu::before,
-    summary span {
-      transition: none !important;
-    }
-  }
+	/* Accessibility */
+	@media (prefers-reduced-motion: reduce) {
+		.panel,
+		.menu::before,
+		summary span {
+			transition: none !important;
+		}
+	}
 
-  /* Hover animatie menu items */
-  .menu-button {
-    font-weight: var(--heading-font-weight);
-    color: light-dark(var(--blue-800), var(--blue-150));
-    padding: 0.5rem 1rem;
-    position: relative;
+	/* Hover animatie menu items */
+	.menu-button {
+		font-weight: var(--heading-font-weight);
+		color: light-dark(var(--blue-800), var(--blue-150));
+		padding: 0.5rem 1rem;
+		position: relative;
 
-    &::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      bottom: -2px;
-      height: 2px;
-      width: 0%;
-      background: currentColor;
-      transition: 0.3s ease;
-    }
-  }
+		&::after {
+			content: '';
+			position: absolute;
+			left: 0;
+			bottom: -2px;
+			height: 2px;
+			width: 0%;
+			background: currentColor;
+			transition: 0.3s ease;
+		}
+	}
 
-  .menu-button:hover::after {
-    width: 100%;
-  }
+	.menu-button:hover::after {
+		width: 100%;
+	}
 
-  a {
-    position: relative;
-  }
+	a {
+		position: relative;
+	}
 
-  a.active::after {
-    content: "";
-    position: absolute;
-    left: 0;
-    bottom: -2px;
-    width: 100%;
-    height: 2px;
-    background: currentColor;
-    transform: scaleX(1);
-    transition: 0.3s ease;
-  }
+	a.active::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		bottom: -2px;
+		width: 100%;
+		height: 2px;
+		background: currentColor;
+		transform: scaleX(1);
+		transition: 0.3s ease;
+	}
 </style>

--- a/src/routes/(public)/lados-en-ad-profielen/+page.server.js
+++ b/src/routes/(public)/lados-en-ad-profielen/+page.server.js
@@ -1,0 +1,73 @@
+import { ContentService } from '$lib/server/contentService.js'
+
+const LADO_FIELDS = 'id,title,national_ad_profile,lado_status,contact_persons,status,sectoral_advisory_board'
+const COURSE_FIELDS = 'id,title,lado,cooperations'
+const COOPERATION_FIELDS = 'id,name,url'
+const SECTORAL_ADVISORY_BOARD_FIELDS = 'id,title'
+const PUBLISHED_FILTER = { status: { _eq: 'published' } }
+const LOAD_ERROR = `Er is een probleem opgetreden bij het ophalen van de LAdO's.`
+
+function getRelationId(value) {
+	return value?.id ?? value
+}
+
+function getRelationIds(value) {
+	if (Array.isArray(value)) {
+		return value.map(getRelationId).filter(Boolean)
+	}
+
+	const id = getRelationId(value)
+	return id ? [id] : []
+}
+
+function getUniqueIds(items, selector) {
+	return [...new Set(items.flatMap((item) => getRelationIds(selector(item))))]
+}
+
+function emptyCollection(collection) {
+	return { data: { [collection]: [] }, errors: [] }
+}
+
+function hasErrors(...responses) {
+	return responses.some((response) => response.errors.length > 0)
+}
+
+export async function load() {
+	const ladosResponse = await ContentService.fetchContent('lados', null, LADO_FIELDS, PUBLISHED_FILTER, false)
+	const ladoItems = ladosResponse.data.lados ?? []
+	const ladoIds = getUniqueIds(ladoItems, (lado) => lado.id)
+	const sectoralAdvisoryBoardIds = getUniqueIds(ladoItems, (lado) => getRelationId(lado.sectoral_advisory_board))
+
+	const coursesResponse = ladoIds.length ? await ContentService.fetchContent('courses', null, COURSE_FIELDS, { lado: { _in: ladoIds } }, false) : emptyCollection('courses')
+	const courses = coursesResponse.data.courses ?? []
+	const cooperationIds = getUniqueIds(courses, (course) => course.cooperations)
+
+	const cooperationsResponse = cooperationIds.length
+		? await ContentService.fetchContent('cooperations', null, COOPERATION_FIELDS, { id: { _in: cooperationIds } }, false)
+		: emptyCollection('cooperations')
+	const sectoralAdvisoryBoardsResponse = sectoralAdvisoryBoardIds.length
+		? await ContentService.fetchContent('sectoralAdvisoryBoards', null, SECTORAL_ADVISORY_BOARD_FIELDS, { id: { _in: sectoralAdvisoryBoardIds } }, false)
+		: emptyCollection('sectoralAdvisoryBoards')
+
+	const cooperations = cooperationsResponse.data.cooperations ?? []
+	const sectoralAdvisoryBoards = sectoralAdvisoryBoardsResponse.data.sectoralAdvisoryBoards ?? []
+	const coursesWithCooperation = courses.map((course) => ({
+		...course,
+		cooperations: getRelationIds(course.cooperations)
+			.map((cooperationId) => cooperations.find((cooperation) => String(cooperation.id) === String(cooperationId)))
+			.filter(Boolean)
+	}))
+
+	const lados = ladoItems
+		.map((lado) => ({
+			...lado,
+			sectoral_advisory_board: sectoralAdvisoryBoards.find((board) => String(board.id) === String(getRelationId(lado.sectoral_advisory_board))) ?? lado.sectoral_advisory_board,
+			courses: coursesWithCooperation.filter((course) => String(getRelationId(course.lado)) === String(lado.id))
+		}))
+		.sort((a, b) => (a.title ?? '').localeCompare(b.title ?? '', 'nl', { numeric: true }))
+
+	return {
+		lados,
+		loadError: hasErrors(ladosResponse, coursesResponse, cooperationsResponse, sectoralAdvisoryBoardsResponse) ? LOAD_ERROR : null
+	}
+}

--- a/src/routes/(public)/lados-en-ad-profielen/+page.svelte
+++ b/src/routes/(public)/lados-en-ad-profielen/+page.svelte
@@ -1,0 +1,135 @@
+<script>
+	import { Hero, LadoInfoCard, LadosOverview, overleggen } from '$lib'
+
+	const { data } = $props()
+
+	const infoCards = [
+		{
+			title: 'Gezamenlijke profilering van vergelijkbare Ad-opleidingen',
+			description:
+				'In een LAdO stemmen de aangesloten Ad-opleidingen met elkaar af over een gezamenlijke profilering om tot landelijk herkenbare opleidingen te komen. Deze profilering is richtinggevend voor (aankomende) studenten, werkgevers en kwaliteitstoetsing door de NVAO.'
+		},
+		{
+			title: 'Gezamenlijke afstemming op het specifieke werkveld',
+			description:
+				'Elke hogeschool heeft met haar eigen regio te maken, maar ook met landelijke werkgeversorganisaties, brancheorganisaties en beroepsverenigingen. Binnen een LAdO wordt hierover gezamenlijk afgestemd.'
+		},
+		{
+			title: 'Gezamenlijke afstemming op andere (overheids)organen',
+			description:
+				"In de LAdO's is regelmatig afstemming met de NVAO, het ministerie van OCW en de Commissie Doelmatigheid Hoger Onderwijs. Opleidingen kunnen veel van elkaar leren als het gaat om accreditaties en onderwijsvernieuwingen."
+		},
+		{
+			title: 'Onderlinge uitwisseling en afstemming over onderwijsuitvoering',
+			description: 'In de ontwikkeling en doorontwikkeling van Ad-opleidingen valt veel van elkaar te leren, bijvoorbeeld over niveau, toetsing, praktijkleren en digitaal onderwijsmateriaal.',
+			open: true
+		}
+	]
+</script>
+
+<svelte:head>
+	<title>LAdO's en Ad-profielen | Overlegplatform Associate Degrees</title>
+</svelte:head>
+
+<Hero
+	title="Landelijke Ad-overleggen en Ad-profielen"
+	description="Het Overlegplatform Associate degrees ondersteunt het belang van Ad-opleidingen om zich samen te positioneren en te profileren in het Nederlandse onderwijslandschap."
+>
+	<a
+		slot="primary"
+		href="#over-lados"
+		class="button-outline-white">Lees meer</a
+	>
+	<a
+		slot="secondary"
+		href="#overzicht-lados"
+		class="button-outline-white">Bekijk overzicht</a
+	>
+	<img
+		class="hero-image"
+		src={overleggen}
+		alt="Mensen tijdens een landelijk overleg over Associate degree-opleidingen"
+		fetchpriority="high"
+	/>
+</Hero>
+
+<section
+	class="lado-info"
+	id="over-lados"
+>
+	<div class="inner-wrapper">
+		<h2>Over LAdO's</h2>
+
+		<div class="card-grid">
+			{#each infoCards as card (card.title)}
+				<LadoInfoCard {...card} />
+			{/each}
+		</div>
+	</div>
+</section>
+
+{#if data.loadError}
+	<section class="load-error">
+		<p>{data.loadError}</p>
+	</section>
+{/if}
+
+<LadosOverview lados={data.lados} />
+
+<style>
+	.hero-image {
+		display: block;
+		width: 100%;
+		height: 20em;
+		object-fit: cover;
+		border-radius: 1em 1em 0 0;
+	}
+
+	.lado-info {
+		background: light-dark(var(--text-white), var(--blue-800));
+		padding: 3em 5%;
+	}
+
+	.inner-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25em;
+		max-width: 1400px;
+		margin: 0 auto;
+	}
+
+	h2 {
+		color: light-dark(var(--blue-800), var(--text-white));
+	}
+
+	.card-grid {
+		display: grid;
+		align-items: start;
+		gap: 1.5em;
+	}
+
+	.load-error {
+		background: light-dark(var(--text-white), var(--blue-800));
+		padding: 0 5%;
+	}
+
+	.load-error p {
+		max-width: 1400px;
+		margin: 0 auto;
+		border: 1px solid var(--primary-orange);
+		border-radius: 0.5em;
+		padding: 1em;
+		color: light-dark(var(--blue-900), var(--text-white));
+	}
+
+	@media (min-width: 768px) {
+		.hero-image {
+			height: 25em;
+			border-radius: 1em;
+		}
+
+		.card-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+</style>


### PR DESCRIPTION
## What does this change?

Resolves issue #614 

Voegt de overzichtpagina toe van de lado's. Deze pagina is gebasseerd op het design van de eerste jaars, met wat aanpassingen zodat deze beter bij de huidige UI/UX passen.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images
<img width="563" height="812" alt="afbeelding" src="https://github.com/user-attachments/assets/ff4b953b-773c-4e4f-af9d-6a1f1aa62bf6" />

<img width="594" height="533" alt="afbeelding" src="https://github.com/user-attachments/assets/a612af95-9905-45e6-a0b1-2de26ce8f228" />

## How to review

1. Ga naar deze branch
2. Open de ADConnect home pagina
3. Ga via de navbar naar het kopje lado's en ad-profielen
4. Check de lado's