### PR TITLE
579 user story atom section separator component

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -98,3 +98,7 @@ export { default as Collaborate } from './assets/collaborate.svg'
 export { default as Events } from './assets/events.svg'
 export { default as Question } from './assets/faq.svg'
 export { default as LadoNetwork } from './assets/lado-network.svg'
+
+// refactored
+// atoms
+export { default as Rseparator } from './refactored/atoms/Separator.svelte'

--- a/src/lib/organisms/NewsCardSection.svelte
+++ b/src/lib/organisms/NewsCardSection.svelte
@@ -1,6 +1,6 @@
 <script>
 	// Import component
-	import { DividerText, NewsCard } from '$lib'
+	import { DividerText, NewsCard, Rseparator } from '$lib'
 
 	// Retrieve news data
 	export let news
@@ -8,7 +8,7 @@
 
 <!-- Cards section -->
 <div class="container">
-	<DividerText text="Het laatste nieuws" />
+	<Rseparator dividerText="Het laatste nieuws" />
 	<ul>
 		{#each news as article (article.uuid)}
 			<li><NewsCard {article} /></li>

--- a/src/lib/refactored/atoms/Separator.svelte
+++ b/src/lib/refactored/atoms/Separator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	let { dividerText } = $props()
+	let { dividerText }: { dividerText: string } = $props()
 </script>
 
 <section>
@@ -21,7 +21,8 @@
 		margin: 2em auto;
 	}
 
-	hr, span {
+	hr,
+	span {
 		flex: 1;
 		border: none;
 		height: 1px;

--- a/src/lib/refactored/atoms/Separator.svelte
+++ b/src/lib/refactored/atoms/Separator.svelte
@@ -1,21 +1,17 @@
-<script>
-	export let text = ''
+<script lang="ts">
+	let { dividerText } = $props()
 </script>
 
-<div class="divider-container">
-	<hr
-		class="line"
-		aria-hidden="true"
-	/>
-	<p>{text}</p>
-	<hr
-		class="line"
-		aria-hidden="true"
-	/>
-</div>
+<section>
+	<hr />
+	{#if dividerText}
+		<p>{dividerText}</p>
+		<hr />
+	{/if}
+</section>
 
 <style>
-	.divider-container {
+	section {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -30,5 +26,9 @@
 		border: none;
 		height: 1px;
 		border-top: 1px solid var(--neutral-300);
+	}
+
+	p {
+		white-space: nowrap;
 	}
 </style>

--- a/src/lib/refactored/atoms/Separator.svelte
+++ b/src/lib/refactored/atoms/Separator.svelte
@@ -6,7 +6,7 @@
 	<hr />
 	{#if dividerText}
 		<p>{dividerText}</p>
-		<hr />
+		<span></span>
 	{/if}
 </section>
 
@@ -21,7 +21,7 @@
 		margin: 2em auto;
 	}
 
-	hr {
+	hr, span {
 		flex: 1;
 		border: none;
 		height: 1px;

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -2,7 +2,7 @@
 	import placeholder from '$lib/assets/placeholder-hero.webp'
 
 	// Import components
-	import { MultipleFaq, SingleFaq, DividerText, Divider, LogoSection, Hero, NewsCardSection, Information, InformationCards, FeatureSplit, Link } from '$lib'
+	import { MultipleFaq, SingleFaq, DividerText, Divider, LogoSection, Hero, NewsCardSection, Information, InformationCards, FeatureSplit, Link, Rseparator } from '$lib'
 
 	// Import images
 	import { zaal } from '$lib'
@@ -77,10 +77,11 @@ Blijf op de hoogte van Ad‑opleidingen en activiteiten binnen het overlegplatfo
 />
 
 <section class="logo-section">
-	<DividerText text="Partijen waarmee wij samenwerken" />
+	<Rseparator dividerText="Partijen waarmee wij samenwerken" />
 	<LogoSection {cooperation} />
-	<Divider />
+	<Rseparator />
 </section>
+
 
 <FeatureSplit
 	title="Waarom kiezen voor een Associate degree?"


### PR DESCRIPTION
## What does this change?

Resolves issue #579

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->


This PR has code for the separator between sections on the page
- An hr element is used because the component creates a visual break between sections throughout the website
- If you provide `dividerText` prop, text will appear in the center between two lines
  - The second line is a span so that screen readers do not announce the separator twice

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

This is a code refactor / a new component using the existing code.
There should be no visual changes.

## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Documentation
- If you read the [documentation for this component]() are you able to use it?

Code:
- review the code for this component: `src/lib/refactored/atoms/Link.svelte`
  - Does this code follow FDND code conventions?
  - is it understandable?
 
