### PR TITLE
623 feature lado moet subclusters kunnen ondersteunen

### DIFF
--- a/src/lib/molecules/LadoAccordionItem.svelte
+++ b/src/lib/molecules/LadoAccordionItem.svelte
@@ -1,15 +1,27 @@
 <script>
 	export let lado = {}
+	export let subclusters = []
+	export let parent = null
+	export let isSubcluster = false
 
 	const contactPersons = Array.isArray(lado.contact_persons) ? lado.contact_persons : []
 	const courses = Array.isArray(lado.courses) ? lado.courses : []
 	const sectoralAdvisoryBoard = typeof lado.sectoral_advisory_board === 'object' ? lado.sectoral_advisory_board : null
+	const parentLado = parent ?? (typeof lado.parent === 'object' ? lado.parent : null)
 </script>
 
-<article>
+<article
+	id={`lado-${lado.id}`}
+	class:is-subcluster={isSubcluster}
+>
 	<details>
 		<summary>
-			<span>{lado.title}</span>
+			<span class="title-wrap">
+				<span>{lado.title}</span>
+				{#if !isSubcluster && subclusters.length > 0}
+					<span class="subcluster-badge">{subclusters.length} subclusters</span>
+				{/if}
+			</span>
 			<span
 				class="toggle"
 				aria-hidden="true"
@@ -17,6 +29,13 @@
 		</summary>
 
 		<div class="content">
+			{#if isSubcluster && parentLado?.id}
+				<p class="parent-reference">
+					<strong>Parent</strong>
+					<a href={`#lado-${parentLado.id}`}>{parentLado.title ?? `Lado ${parentLado.id}`}</a>
+				</p>
+			{/if}
+
 			{#if lado.national_ad_profile}
 				<p><strong>Landelijk Ad-profiel</strong>{lado.national_ad_profile}</p>
 			{/if}
@@ -69,6 +88,19 @@
 					</ul>
 				</section>
 			{/if}
+
+			{#if !isSubcluster && subclusters.length > 0}
+				<section aria-label="Subclusters">
+					<strong>Subclusters ({subclusters.length})</strong>
+					<ul class="subcluster-links">
+						{#each subclusters as subcluster (subcluster.id)}
+							<li>
+								<a href={`#lado-${subcluster.id}`}>{subcluster.title ?? `Lado ${subcluster.id}`}</a>
+							</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
 		</div>
 	</details>
 </article>
@@ -86,6 +118,10 @@
 		border: 1px solid var(--_border);
 		border-radius: 0.45em;
 		color: var(--_text);
+	}
+
+	article.is-subcluster {
+		border-left: 4px solid var(--primary-blue);
 	}
 
 	details {
@@ -107,6 +143,26 @@
 
 	summary::-webkit-details-marker {
 		display: none;
+	}
+
+	.title-wrap {
+		display: inline-flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5em;
+	}
+
+	.subcluster-badge {
+		display: inline-flex;
+		align-items: center;
+		border-radius: 999px;
+		padding: 0.2em 0.65em;
+		background: var(--primary-blue);
+		color: var(--text-white);
+		font-family: var(--font-body);
+		font-size: 0.78rem;
+		font-weight: var(--weight-semibold);
+		line-height: 1.2;
 	}
 
 	.toggle {
@@ -153,6 +209,13 @@
 	section {
 		display: grid;
 		gap: 0.35em;
+	}
+
+	.parent-reference {
+		align-items: start;
+		padding: 0.6em 0.75em;
+		border-radius: 0.45em;
+		background: var(--_chip-background);
 	}
 
 	strong {
@@ -224,6 +287,16 @@
 
 	.cooperation-item {
 		line-height: 1.25;
+	}
+
+	.subcluster-links {
+		display: grid;
+		gap: 0.35em;
+	}
+
+	.subcluster-links a {
+		font-family: var(--font-body);
+		font-size: 0.95rem;
 	}
 
 	a {

--- a/src/lib/organisms/LadosOverview.svelte
+++ b/src/lib/organisms/LadosOverview.svelte
@@ -2,6 +2,28 @@
 	import LadoAccordionItem from '$lib/molecules/LadoAccordionItem.svelte'
 
 	export let lados = []
+	let sortedLados = []
+	let ladoIds = new Set()
+	let rootLados = []
+	let leftColumnLados = []
+	let rightColumnLados = []
+
+	function getRelationId(value) {
+		return value?.id ?? value
+	}
+
+	$: sortedLados = [...lados].sort((a, b) => (a?.title ?? '').localeCompare(b?.title ?? '', 'nl', { numeric: true }))
+	$: ladoIds = new Set(sortedLados.map((lado) => String(lado?.id ?? '')).filter(Boolean))
+	$: rootLados = sortedLados.filter((lado) => {
+		const parentId = String(getRelationId(lado?.parent) ?? '')
+		return !parentId || !ladoIds.has(parentId)
+	})
+	$: leftColumnLados = rootLados.filter((_, index) => index % 2 === 0)
+	$: rightColumnLados = rootLados.filter((_, index) => index % 2 === 1)
+
+	function getSubclusters(parentId) {
+		return sortedLados.filter((lado) => String(getRelationId(lado?.parent) ?? '') === String(parentId))
+	}
 </script>
 
 <section
@@ -15,10 +37,78 @@
 		</div>
 
 		{#if lados.length}
-			<div class="lados-grid">
-				{#each lados as lado (lado.id)}
-					<LadoAccordionItem {lado} />
+			<div class="lados-list-mobile">
+				{#each rootLados as lado (lado.id)}
+					{@const subclusters = getSubclusters(lado.id)}
+					<div class="lado-group">
+						<LadoAccordionItem
+							{lado}
+							{subclusters}
+						/>
+
+						{#if subclusters.length}
+							<div class="subcluster-list">
+								{#each subclusters as subcluster (subcluster.id)}
+									<LadoAccordionItem
+										lado={subcluster}
+										parent={lado}
+										isSubcluster={true}
+									/>
+								{/each}
+							</div>
+						{/if}
+					</div>
 				{/each}
+			</div>
+
+			<div class="lados-grid-desktop">
+				<div class="lados-column">
+					{#each leftColumnLados as lado (lado.id)}
+						{@const subclusters = getSubclusters(lado.id)}
+						<div class="lado-group">
+							<LadoAccordionItem
+								{lado}
+								{subclusters}
+							/>
+
+							{#if subclusters.length}
+								<div class="subcluster-list">
+									{#each subclusters as subcluster (subcluster.id)}
+										<LadoAccordionItem
+											lado={subcluster}
+											parent={lado}
+											isSubcluster={true}
+										/>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+
+				<div class="lados-column">
+					{#each rightColumnLados as lado (lado.id)}
+						{@const subclusters = getSubclusters(lado.id)}
+						<div class="lado-group">
+							<LadoAccordionItem
+								{lado}
+								{subclusters}
+							/>
+
+							{#if subclusters.length}
+								<div class="subcluster-list">
+									{#each subclusters as subcluster (subcluster.id)}
+										<LadoAccordionItem
+											lado={subcluster}
+											parent={lado}
+											isSubcluster={true}
+										/>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
 			</div>
 		{:else}
 			<p class="empty-state">Er zijn nog geen gepubliceerde LAdO's gevonden.</p>
@@ -56,10 +146,33 @@
 		font-size: var(--p-xs-size);
 	}
 
-	.lados-grid {
+	.lados-list-mobile {
 		display: grid;
 		align-items: start;
 		gap: 1em;
+	}
+
+	.lados-grid-desktop {
+		display: none;
+	}
+
+	.lados-column {
+		display: grid;
+		align-items: start;
+		gap: 1em;
+	}
+
+	.lado-group {
+		display: grid;
+		gap: 0.75em;
+	}
+
+	.subcluster-list {
+		display: grid;
+		gap: 0.65em;
+		margin-left: 1.1em;
+		padding-left: 0.95em;
+		border-left: 4px solid var(--primary-blue);
 	}
 
 	.empty-state {
@@ -71,8 +184,15 @@
 	}
 
 	@media (min-width: 768px) {
-		.lados-grid {
+		.lados-list-mobile {
+			display: none;
+		}
+
+		.lados-grid-desktop {
+			display: grid;
 			grid-template-columns: repeat(2, minmax(0, 1fr));
+			align-items: start;
+			gap: 1em;
 		}
 	}
 </style>

--- a/src/lib/organisms/forms/LadosForm.svelte
+++ b/src/lib/organisms/forms/LadosForm.svelte
@@ -24,6 +24,7 @@
 	let selectedCourseIds = $state([])
 	let selectedParent = $state('')
 	let selectedSectoralAdvisoryBoard = $state('')
+	let parentSearch = $state('')
 	let courseSearch = $state('')
 	let titleSource = $state('')
 	let nationalAdProfileSource = $state('')
@@ -36,6 +37,10 @@
 	const courseAddHref = '/admin/courses/create'
 	const sectoralAdvisoryBoardAddHref = '/admin/sectoral-advisory-boards/create'
 	const availableParentLados = $derived(lados.filter((currentLado) => String(currentLado?.id ?? '') !== String(lado?.id ?? '')))
+	const normalizedParentSearch = $derived(parentSearch.trim().toLowerCase())
+	const filteredParentLados = $derived(
+		normalizedParentSearch ? availableParentLados.filter((parentLado) => (parentLado.title ?? `Hoofd-lado ${parentLado.id}`).toLowerCase().includes(normalizedParentSearch)) : availableParentLados
+	)
 	const normalizedCourseSearch = $derived(courseSearch.trim().toLowerCase())
 	const filteredCourses = $derived(normalizedCourseSearch ? courses.filter((course) => (course.title ?? `Opleiding ${course.id}`).toLowerCase().includes(normalizedCourseSearch)) : courses)
 
@@ -61,6 +66,15 @@
 		}
 
 		selectedCourseIds = [...selectedCourseIds, normalizedId]
+	}
+
+	function isParentSelected(parentLadoId) {
+		return selectedParent === String(parentLadoId)
+	}
+
+	function toggleParentSelection(parentLadoId) {
+		const normalizedId = String(parentLadoId)
+		selectedParent = selectedParent === normalizedId ? '' : normalizedId
 	}
 
 	function addTag() {
@@ -109,6 +123,7 @@
 			tagInput = ''
 			selectedCourseIds = []
 			selectedParent = ''
+			parentSearch = ''
 			courseSearch = ''
 		}
 
@@ -264,30 +279,60 @@
 	<div class="field-group">
 		<div class="field-heading-row">
 			<label
-				for="parent"
+				for="parentSearch"
 				class="field-label">Hoofd-lado</label
 			>
 		</div>
 		{#if availableParentLados.length === 0}
 			<p class="field-help">Geen lado's gevonden om als hoofd-lado te selecteren.</p>
-			<select
-				id="parent"
-				name="parent"
-				disabled
-			>
-				<option value="">Geen hoofd-lado's beschikbaar</option>
-			</select>
+			<div class="courses-picker courses-picker-disabled">
+				<p class="field-help">Geen hoofd-lado's beschikbaar</p>
+			</div>
 		{:else}
-			<select
-				id="parent"
-				name="parent"
-				bind:value={selectedParent}
-			>
-				<option value="">Geen hoofd-lado beschikbaar</option>
-				{#each availableParentLados as parentLado (parentLado.id)}
-					<option value={String(parentLado.id)}>{parentLado.title ?? `Hoofd-lado ${parentLado.id}`}</option>
-				{/each}
-			</select>
+			<div class="courses-picker">
+				<div class="courses-toolbar">
+					<input
+						id="parentSearch"
+						type="text"
+						class="course-search"
+						placeholder="Zoek hoofd-lado"
+						autocomplete="off"
+						bind:value={parentSearch}
+					/>
+					<p class="courses-count">{selectedParent ? '1 geselecteerd' : '0 geselecteerd'}</p>
+				</div>
+
+				<div
+					class="courses-list"
+					role="listbox"
+					aria-multiselectable="false"
+					aria-label="Selecteer hoofd-lado"
+				>
+					{#if filteredParentLados.length === 0}
+						<p class="field-help courses-empty">Geen hoofd-lado's gevonden voor deze zoekterm.</p>
+					{:else}
+						{#each filteredParentLados as parentLado (parentLado.id)}
+							<label
+								class="course-option"
+								class:course-option-selected={isParentSelected(parentLado.id)}
+							>
+								<input
+									type="checkbox"
+									checked={isParentSelected(parentLado.id)}
+									onchange={() => toggleParentSelection(parentLado.id)}
+								/>
+								<span>{parentLado.title ?? `Hoofd-lado ${parentLado.id}`}</span>
+							</label>
+						{/each}
+					{/if}
+				</div>
+
+				<input
+					type="hidden"
+					name="parent"
+					value={selectedParent}
+				/>
+			</div>
 		{/if}
 		<p class="field-help">Optioneel: koppel deze lado aan een bestaande hoofd-lado.</p>
 	</div>

--- a/src/lib/organisms/forms/LadosForm.svelte
+++ b/src/lib/organisms/forms/LadosForm.svelte
@@ -263,16 +263,19 @@
 
 	<div class="field-group">
 		<div class="field-heading-row">
-			<p class="field-label">Parent</p>
+			<label
+				for="parent"
+				class="field-label">Hoofd-lado</label
+			>
 		</div>
 		{#if availableParentLados.length === 0}
-			<p class="field-help">Geen lado's gevonden om als parent te selecteren.</p>
+			<p class="field-help">Geen lado's gevonden om als hoofd-lado te selecteren.</p>
 			<select
 				id="parent"
 				name="parent"
 				disabled
 			>
-				<option value="">Geen parent-lado's beschikbaar</option>
+				<option value="">Geen hoofd-lado's beschikbaar</option>
 			</select>
 		{:else}
 			<select
@@ -280,18 +283,21 @@
 				name="parent"
 				bind:value={selectedParent}
 			>
-				<option value="">Geen parent</option>
+				<option value="">Geen hoofd-lado beschikbaar</option>
 				{#each availableParentLados as parentLado (parentLado.id)}
-					<option value={String(parentLado.id)}>{parentLado.title ?? `Lado ${parentLado.id}`}</option>
+					<option value={String(parentLado.id)}>{parentLado.title ?? `Hoofd-lado ${parentLado.id}`}</option>
 				{/each}
 			</select>
 		{/if}
-		<p class="field-help">Optioneel: koppel deze lado aan een bestaande parent-lado.</p>
+		<p class="field-help">Optioneel: koppel deze lado aan een bestaande hoofd-lado.</p>
 	</div>
 
 	<div class="field-group">
 		<div class="field-heading-row">
-			<p class="field-label">Sectoraal adviescollege</p>
+			<label
+				for="sectoralAdvisoryBoard"
+				class="field-label">Sectoraal adviescollege</label
+			>
 			<a
 				href={sectoralAdvisoryBoardAddHref}
 				target="_blank"

--- a/src/lib/organisms/forms/LadosForm.svelte
+++ b/src/lib/organisms/forms/LadosForm.svelte
@@ -1,7 +1,19 @@
 <script>
 	import Form from '$lib/organisms/forms/Form.svelte'
 
-	const { form, lado = null, courses = [], sectoralAdvisoryBoards = [], sectoralAdvisoryBoardId = '', directusBase = '', showPublishButton = false, resetOnSuccess = true, onSuccess = null } = $props()
+	const {
+		form,
+		lado = null,
+		lados = [],
+		parentId = '',
+		courses = [],
+		sectoralAdvisoryBoards = [],
+		sectoralAdvisoryBoardId = '',
+		directusBase = '',
+		showPublishButton = false,
+		resetOnSuccess = true,
+		onSuccess = null
+	} = $props()
 
 	let title = $state('')
 	let nationalAdProfile = $state('')
@@ -10,6 +22,7 @@
 	let tagInput = $state('')
 	let tagsInputElement = $state()
 	let selectedCourseIds = $state([])
+	let selectedParent = $state('')
 	let selectedSectoralAdvisoryBoard = $state('')
 	let courseSearch = $state('')
 	let titleSource = $state('')
@@ -17,10 +30,12 @@
 	let ladoStatusSource = $state('')
 	let contactPersonsSource = $state('')
 	let selectedCourseIdsSource = $state('')
+	let selectedParentSource = $state('')
 	let selectedSectoralAdvisoryBoardSource = $state('')
 
 	const courseAddHref = '/admin/courses/create'
 	const sectoralAdvisoryBoardAddHref = '/admin/sectoral-advisory-boards/create'
+	const availableParentLados = $derived(lados.filter((currentLado) => String(currentLado?.id ?? '') !== String(lado?.id ?? '')))
 	const normalizedCourseSearch = $derived(courseSearch.trim().toLowerCase())
 	const filteredCourses = $derived(normalizedCourseSearch ? courses.filter((course) => (course.title ?? `Opleiding ${course.id}`).toLowerCase().includes(normalizedCourseSearch)) : courses)
 
@@ -93,6 +108,7 @@
 			tags = []
 			tagInput = ''
 			selectedCourseIds = []
+			selectedParent = ''
 			courseSearch = ''
 		}
 
@@ -146,6 +162,13 @@
 
 		const ladoId = String(lado?.id ?? '')
 		selectedCourseIds = ladoId ? courses.filter((course) => String(course?.lado?.id ?? course?.lado ?? '') === ladoId).map((course) => String(course.id)) : []
+	})
+
+	$effect(() => {
+		const nextSource = String(form?.parent ?? parentId ?? lado?.parent?.id ?? lado?.parent ?? '')
+		if (nextSource === selectedParentSource) return
+		selectedParentSource = nextSource
+		selectedParent = nextSource
 	})
 
 	$effect(() => {
@@ -236,6 +259,34 @@
 			bind:value={ladoStatus}
 			required
 		/>
+	</div>
+
+	<div class="field-group">
+		<div class="field-heading-row">
+			<p class="field-label">Parent</p>
+		</div>
+		{#if availableParentLados.length === 0}
+			<p class="field-help">Geen lado's gevonden om als parent te selecteren.</p>
+			<select
+				id="parent"
+				name="parent"
+				disabled
+			>
+				<option value="">Geen parent-lado's beschikbaar</option>
+			</select>
+		{:else}
+			<select
+				id="parent"
+				name="parent"
+				bind:value={selectedParent}
+			>
+				<option value="">Geen parent</option>
+				{#each availableParentLados as parentLado (parentLado.id)}
+					<option value={String(parentLado.id)}>{parentLado.title ?? `Lado ${parentLado.id}`}</option>
+				{/each}
+			</select>
+		{/if}
+		<p class="field-help">Optioneel: koppel deze lado aan een bestaande parent-lado.</p>
 	</div>
 
 	<div class="field-group">

--- a/src/routes/(public)/lados-en-ad-profielen/+page.server.js
+++ b/src/routes/(public)/lados-en-ad-profielen/+page.server.js
@@ -1,6 +1,6 @@
 import { ContentService } from '$lib/server/contentService.js'
 
-const LADO_FIELDS = 'id,title,national_ad_profile,lado_status,contact_persons,status,sectoral_advisory_board'
+const LADO_FIELDS = 'id,title,national_ad_profile,lado_status,contact_persons,status,parent,sectoral_advisory_board'
 const COURSE_FIELDS = 'id,title,lado,cooperations.adconnect_cooperation_id.id,cooperations.adconnect_cooperation_id.name,cooperations.adconnect_cooperation_id.url'
 const SECTORAL_ADVISORY_BOARD_FIELDS = 'id,title'
 const PUBLISHED_FILTER = { status: { _eq: 'published' } }
@@ -54,10 +54,12 @@ export async function load() {
 		...course,
 		cooperations: getCourseCooperations(course)
 	}))
+	const ladoById = new Map(ladoItems.map((lado) => [String(lado.id), lado]))
 
 	const lados = ladoItems
 		.map((lado) => ({
 			...lado,
+			parent: ladoById.get(String(getRelationId(lado.parent))) ?? lado.parent,
 			sectoral_advisory_board: sectoralAdvisoryBoards.find((board) => String(board.id) === String(getRelationId(lado.sectoral_advisory_board))) ?? lado.sectoral_advisory_board,
 			courses: coursesWithCooperation.filter((course) => String(getRelationId(course.lado)) === String(lado.id))
 		}))

--- a/src/routes/admin/lados/[id]/edit/+page.server.js
+++ b/src/routes/admin/lados/[id]/edit/+page.server.js
@@ -18,8 +18,10 @@ export async function load({ params, cookies }) {
 	if (!ladoId) {
 		return {
 			lado: null,
+			lados: [],
 			courses: [],
 			selectedCourseIds: [],
+			parentId: '',
 			sectoralAdvisoryBoardId: '',
 			sectoralAdvisoryBoards: [],
 			loadError: GENERIC_LOAD_ERROR
@@ -28,36 +30,49 @@ export async function load({ params, cookies }) {
 
 	const token = cookies.get('access_token')
 
-	const [{ data: ladoContent, errors: ladoErrors = [] }, { data: coursesContent, errors: coursesErrors = [] }, { data: boardsContent, errors: boardsErrors = [] }] = await Promise.all([
+	const [
+		{ data: ladoContent, errors: ladoErrors = [] },
+		{ data: ladosContent, errors: ladosErrors = [] },
+		{ data: coursesContent, errors: coursesErrors = [] },
+		{ data: boardsContent, errors: boardsErrors = [] }
+	] = await Promise.all([
 		ContentService.fetchContent('lados', ladoId, null, null, false, token),
+		ContentService.fetchContent('lados', null, null, null, false, token),
 		ContentService.fetchContent('courses', null, null, null, false, token),
 		ContentService.fetchContent('sectoralAdvisoryBoards', null, null, null, false, token)
 	])
 
 	const lado = Array.isArray(ladoContent.lados) ? (ladoContent.lados[0] ?? null) : null
+	const lados = Array.isArray(ladosContent.lados) ? [...ladosContent.lados] : ladosContent.lados ? [...ladosContent.lados.values()] : []
+	lados.sort((a, b) => (a?.title ?? '').localeCompare(b?.title ?? '', 'nl'))
 	const courses = Array.isArray(coursesContent.courses) ? [...coursesContent.courses] : []
 	courses.sort((a, b) => (a?.title ?? '').localeCompare(b?.title ?? '', 'nl'))
 
 	const sectoralAdvisoryBoards = Array.isArray(boardsContent.sectoralAdvisoryBoards) ? [...boardsContent.sectoralAdvisoryBoards] : []
 	sectoralAdvisoryBoards.sort((a, b) => (a?.title ?? '').localeCompare(b?.title ?? '', 'nl'))
 
-	if (ladoErrors.length > 0 || coursesErrors.length > 0 || boardsErrors.length > 0 || !lado) {
+	if (ladoErrors.length > 0 || ladosErrors.length > 0 || coursesErrors.length > 0 || boardsErrors.length > 0 || !lado) {
 		return {
 			lado: null,
+			lados: [],
 			courses: [],
 			selectedCourseIds: [],
+			parentId: '',
 			sectoralAdvisoryBoardId: '',
 			sectoralAdvisoryBoards: [],
 			loadError: GENERIC_LOAD_ERROR
 		}
 	}
 
+	const parentId = String(lado?.parent?.id ?? lado?.parent ?? '')
 	const sectoralAdvisoryBoardId = String(lado?.sectoral_advisory_board?.id ?? lado?.sectoral_advisory_board ?? '')
 
 	return {
 		lado,
+		lados,
 		courses,
 		selectedCourseIds: getLinkedCourseIds(courses, ladoId),
+		parentId,
 		sectoralAdvisoryBoardId,
 		sectoralAdvisoryBoards,
 		loadError: null
@@ -73,6 +88,7 @@ export const actions = {
 		const title = String(data.get('title') ?? '').trim()
 		const nationalAdProfile = String(data.get('nationalAdProfile') ?? '').trim()
 		const ladoStatus = String(data.get('ladoStatus') ?? '').trim()
+		const parent = String(data.get('parent') ?? '').trim()
 		const courseIds = data
 			.getAll('courses')
 			.map((id) => String(id ?? '').trim())
@@ -86,6 +102,7 @@ export const actions = {
 			contactPersons,
 			nationalAdProfile,
 			ladoStatus,
+			parent,
 			sectoralAdvisoryBoard,
 			courses: courseIds
 		}
@@ -141,12 +158,22 @@ export const actions = {
 			return fail(400, { error: 'Kies een geldig sectoraal adviescollege.', ...submittedFormState })
 		}
 
+		const parentId = parent ? Number(parent) : null
+		if (parent && (!Number.isInteger(parentId) || parentId <= 0)) {
+			return fail(400, { error: 'Kies een geldige parent-lado.', ...submittedFormState })
+		}
+
+		if (parentId !== null && String(parentId) === ladoId) {
+			return fail(400, { error: 'Een lado kan niet zijn eigen parent zijn.', ...submittedFormState })
+		}
+
 		try {
 			const payload = {
 				title,
 				contact_persons: contactPersons,
 				national_ad_profile: nationalAdProfile,
 				lado_status: ladoStatus,
+				parent: parentId,
 				sectoral_advisory_board: sectoralAdvisoryBoardId,
 				courseIds
 			}

--- a/src/routes/admin/lados/[id]/edit/+page.svelte
+++ b/src/routes/admin/lados/[id]/edit/+page.svelte
@@ -27,6 +27,8 @@
 <LadosForm
 	{form}
 	lado={data?.lado}
+	lados={data?.lados ?? []}
+	parentId={data?.parentId ?? ''}
 	courses={data?.courses ?? []}
 	sectoralAdvisoryBoards={data?.sectoralAdvisoryBoards ?? []}
 	sectoralAdvisoryBoardId={data?.sectoralAdvisoryBoardId ?? ''}

--- a/src/routes/admin/lados/[id]/edit/lados.edit.server.test.js
+++ b/src/routes/admin/lados/[id]/edit/lados.edit.server.test.js
@@ -33,6 +33,7 @@ function createActionEvent({ fields = {}, accessToken = 'token-123', id = 'lado-
 					contactPersons: JSON.stringify(['Persoon 1']),
 					nationalAdProfile: 'Nationaal profiel',
 					ladoStatus: 'Actief',
+					parent: '',
 					courses: ['222', '333'],
 					sectoralAdvisoryBoard: '456',
 					submitAction: 'save',
@@ -55,7 +56,26 @@ describe('admin lados edit load', () => {
 		ContentService.fetchContent
 			.mockResolvedValueOnce({
 				data: {
-					lados: [{ id: 'lado-789', title: 'Bedrijf X', contact_persons: ['Persoon 1'], national_ad_profile: 'Nationaal profiel', lado_status: 'Actief', sectoral_advisory_board: 456 }]
+					lados: [
+						{
+							id: 'lado-789',
+							title: 'Bedrijf X',
+							contact_persons: ['Persoon 1'],
+							national_ad_profile: 'Nationaal profiel',
+							lado_status: 'Actief',
+							parent: 12,
+							sectoral_advisory_board: 456
+						}
+					]
+				},
+				errors: []
+			})
+			.mockResolvedValueOnce({
+				data: {
+					lados: [
+						{ id: 'lado-12', title: 'Business' },
+						{ id: 'lado-22', title: 'Zorg' }
+					]
 				},
 				errors: []
 			})
@@ -90,11 +110,17 @@ describe('admin lados edit load', () => {
 				id: 'lado-789',
 				title: 'Bedrijf X'
 			},
+			lados: [
+				{ id: 'lado-12', title: 'Business' },
+				{ id: 'lado-22', title: 'Zorg' }
+			],
 			courses: [
 				{ id: 'course-a', title: 'Administratie', lado: 'other-lado' },
 				{ id: 'course-b', title: 'Zorg', lado: 'lado-789' }
 			],
 			selectedCourseIds: ['course-b'],
+			parentId: '12',
+			sectoralAdvisoryBoardId: '456',
 			sectoralAdvisoryBoards: [
 				{ id: 'board-a', title: 'Economie' },
 				{ id: 'board-b', title: 'Techniek' }
@@ -150,6 +176,7 @@ describe('admin lados edit actions.default', () => {
 				contact_persons: ['Persoon 1'],
 				national_ad_profile: 'Nationaal profiel',
 				lado_status: 'Actief',
+				parent: null,
 				sectoral_advisory_board: 456,
 				courseIds: ['222', '333']
 			},
@@ -158,5 +185,43 @@ describe('admin lados edit actions.default', () => {
 		)
 		expect(ContentService.updateContent).toHaveBeenNthCalledWith(2, 333, { lado: 'lado-789' }, 'courses', 'token-123')
 		expect(ContentService.updateContent).toHaveBeenNthCalledWith(3, '111', { lado: null }, 'courses', 'token-123')
+	})
+
+	it('updates lado with selected parent id', async () => {
+		const event = createActionEvent({ fields: { parent: '42' } })
+		ContentService.updateContent.mockResolvedValueOnce({ success: true, id: 'lado-789' })
+		ContentService.fetchContent.mockResolvedValueOnce({
+			data: {
+				courses: [
+					{ id: 222, title: 'Opleiding 2', lado: 'lado-789' },
+					{ id: 333, title: 'Opleiding 3', lado: 'lado-789' }
+				]
+			},
+			errors: []
+		})
+
+		await actions.default(event)
+
+		expect(ContentService.updateContent).toHaveBeenNthCalledWith(
+			1,
+			'lado-789',
+			expect.objectContaining({
+				parent: 42
+			}),
+			'lados',
+			'token-123'
+		)
+	})
+
+	it('returns 400 when parent equals current lado id', async () => {
+		const event = createActionEvent({ id: '789', fields: { parent: '789' } })
+
+		const result = await actions.default(event)
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Een lado kan niet zijn eigen parent zijn.' }
+		})
+		expect(ContentService.updateContent).not.toHaveBeenCalled()
 	})
 })

--- a/src/routes/admin/lados/create/+page.server.js
+++ b/src/routes/admin/lados/create/+page.server.js
@@ -18,6 +18,11 @@ export async function load({ cookies }) {
 		cookies.get('access_token')
 	)
 
+	const { data: ladosContent } = await ContentService.fetchContent('lados', null, null, null, true, cookies.get('access_token'))
+
+	const lados = ladosContent.lados ? [...ladosContent.lados.values()] : []
+	lados.sort((a, b) => (a?.title ?? '').localeCompare(b?.title ?? '', 'nl'))
+
 	const courses = coursesContent.courses ? [...coursesContent.courses.values()] : []
 	courses.sort((a, b) => (a?.title ?? '').localeCompare(b?.title ?? '', 'nl'))
 
@@ -27,6 +32,7 @@ export async function load({ cookies }) {
 	return {
 		courses,
 		sectoralAdvisoryBoards,
+		lados,
 		loadError: coursesErrors.length ? 'Opleidingen konden niet worden geladen.' : sectoralAdvisoryBoardErrors.length ? 'Sectoraal adviescolleges konden niet worden geladen.' : null
 	}
 }
@@ -40,6 +46,7 @@ export const actions = {
 		const title = String(data.get('title') ?? '').trim()
 		const nationalAdProfile = String(data.get('nationalAdProfile') ?? '').trim()
 		const ladoStatus = String(data.get('ladoStatus') ?? '').trim()
+		const parentId = String(data.get('parent') ?? '').trim() || null
 		const courseIds = data
 			.getAll('courses')
 			.map((id) => String(id ?? '').trim())
@@ -110,6 +117,7 @@ export const actions = {
 				national_ad_profile: nationalAdProfile,
 				lado_status: ladoStatus,
 				sectoral_advisory_board: sectoralAdvisoryBoardId,
+				parent: parentId,
 				status: 'draft',
 				courseIds,
 				shouldPublish

--- a/src/routes/admin/lados/create/+page.server.js
+++ b/src/routes/admin/lados/create/+page.server.js
@@ -46,7 +46,8 @@ export const actions = {
 		const title = String(data.get('title') ?? '').trim()
 		const nationalAdProfile = String(data.get('nationalAdProfile') ?? '').trim()
 		const ladoStatus = String(data.get('ladoStatus') ?? '').trim()
-		const parentId = String(data.get('parent') ?? '').trim() || null
+		const parent = String(data.get('parent') ?? '').trim()
+		const parentId = parent ? Number(parent) : null
 		const courseIds = data
 			.getAll('courses')
 			.map((id) => String(id ?? '').trim())
@@ -60,6 +61,7 @@ export const actions = {
 			contactPersons,
 			nationalAdProfile,
 			ladoStatus,
+			parent,
 			sectoralAdvisoryBoard,
 			courses: courseIds
 		}
@@ -108,6 +110,10 @@ export const actions = {
 		const sectoralAdvisoryBoardId = Number(sectoralAdvisoryBoard)
 		if (!Number.isInteger(sectoralAdvisoryBoardId) || sectoralAdvisoryBoardId <= 0) {
 			return fail(400, { error: 'Kies een geldig sectoraal adviescollege.', ...submittedFormState })
+		}
+
+		if (parent && (!Number.isInteger(parentId) || parentId <= 0)) {
+			return fail(400, { error: 'Kies een geldige parent-lado.', ...submittedFormState })
 		}
 
 		try {

--- a/src/routes/admin/lados/create/+page.svelte
+++ b/src/routes/admin/lados/create/+page.svelte
@@ -26,6 +26,7 @@
 
 <LadosForm
 	{form}
+	lados={data?.lados ?? []}
 	courses={data?.courses ?? []}
 	sectoralAdvisoryBoards={data?.sectoralAdvisoryBoards ?? []}
 	{directusBase}

--- a/src/routes/admin/lados/create/lados.create.svelte.test.js
+++ b/src/routes/admin/lados/create/lados.create.svelte.test.js
@@ -29,6 +29,7 @@ function createValidFormFields(overrides = {}) {
 		contactPersons: JSON.stringify(['Persoon 1']),
 		nationalAdProfile: 'Nationaal profiel',
 		ladoStatus: 'Actief',
+		parent: '',
 		courses: '123',
 		sectoralAdvisoryBoard: '456',
 		submitAction: 'save',
@@ -63,7 +64,7 @@ describe('admin lados form load', () => {
 		vi.clearAllMocks()
 	})
 
-	it('returns sorted course and sectoral advisory board options', async () => {
+	it('returns sorted course, parent lado and sectoral advisory board options', async () => {
 		ContentService.fetchContent
 			.mockResolvedValueOnce({
 				data: {
@@ -83,6 +84,15 @@ describe('admin lados form load', () => {
 				},
 				errors: []
 			})
+			.mockResolvedValueOnce({
+				data: {
+					lados: new Map([
+						['lado-b', { id: 'lado-b', title: 'Zorg en Welzijn' }],
+						['lado-a', { id: 'lado-a', title: 'Business' }]
+					])
+				},
+				errors: []
+			})
 
 		const result = await load({
 			cookies: {
@@ -91,6 +101,10 @@ describe('admin lados form load', () => {
 		})
 
 		expect(result).toMatchObject({
+			lados: [
+				{ id: 'lado-a', title: 'Business' },
+				{ id: 'lado-b', title: 'Zorg en Welzijn' }
+			],
 			courses: [
 				{ id: 'course-a', title: 'Administratie' },
 				{ id: 'course-b', title: 'Zorg' }
@@ -193,6 +207,18 @@ describe('admin lados form actions.default', () => {
 		expectNoMutationCalls()
 	})
 
+	it('returns 400 when parent lado is invalid', async () => {
+		const event = createActionEvent({ fields: { parent: 'abc' } })
+
+		const result = await actions.default(event)
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Kies een geldige parent-lado.' }
+		})
+		expectNoMutationCalls()
+	})
+
 	it('saves lado as draft and returns success payload', async () => {
 		const event = createActionEvent()
 		mockSuccessfulCreate()
@@ -212,6 +238,7 @@ describe('admin lados form actions.default', () => {
 				national_ad_profile: 'Nationaal profiel',
 				lado_status: 'Actief',
 				sectoral_advisory_board: 456,
+				parent: null,
 				status: 'draft',
 				courseIds: ['123'],
 				shouldPublish: false
@@ -222,6 +249,21 @@ describe('admin lados form actions.default', () => {
 		expect(ContentService.updateContent).toHaveBeenCalledTimes(1)
 		expect(ContentService.updateContent).toHaveBeenCalledWith(123, { lado: 'lado-789' }, 'courses', 'token-123')
 		expect(ContentService.publishContent).not.toHaveBeenCalled()
+	})
+
+	it('saves lado with selected parent id', async () => {
+		const event = createActionEvent({ fields: { parent: '88' } })
+		mockSuccessfulCreate()
+
+		await actions.default(event)
+
+		expect(ContentService.postContent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				parent: 88
+			}),
+			'lados',
+			'token-123'
+		)
 	})
 
 	it('links multiple courses to lado', async () => {


### PR DESCRIPTION
## What does this change?

Resolves issue #623 

Voegt de parent en children velden toe aan de lado collectie in directus. Haalt verder de parent veld op en geeft deze weer in directus, de parent veld bevat een lijst met bestaande lado's zodat een lado gekoppeld kan worden aan een andere lado. Dit komt doordat er subclusters bestaan die aan een grotere overkoepelende lado gekoppeld zijn.

Op de adconnect lado pagina, geeft zich dit weer als sub rijen die gekoppeld zijn aan een hoofd-lado.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<img width="1249" height="710" alt="image" src="https://github.com/user-attachments/assets/0008f3e5-e182-4fbc-a82c-6050c8b45d3f" />
<img width="587" height="569" alt="image" src="https://github.com/user-attachments/assets/28726eef-6897-4f92-82c5-a195bf34995c" />
<img width="719" height="390" alt="image" src="https://github.com/user-attachments/assets/2008f796-8c3a-41e9-a9d1-f0c31f00a8de" />

## How to review

1. Ga naar deze branch
2. Ga naar het admin paneel
3. Druk om een nieuwe lado toe te voegen
4. Kies uit de lijst van lado's het hoofd-lado
5. Klik op publiceer
6. Ga naar de adconnect website en op de lado pagina
7. Kijk of de sublado correct gekoppeld is aan een hoofd-lado