### PR TITLE
650 feature dynamisch ophalen van home pagina content

### DIFF
--- a/src/lib/organisms/FeatureSplit.svelte
+++ b/src/lib/organisms/FeatureSplit.svelte
@@ -24,7 +24,9 @@
 		<h2 class="feature-title">{title}</h2>
 
 		{#if intro}
-			<p class="feature-intro">{intro}</p>
+			: <div class="feature-intro">
+				{@html intro}
+			</div>
 		{/if}
 
 		{#if bullets?.length}
@@ -87,6 +89,53 @@
 		p {
 			text-align: left;
 		}
+	}
+
+	.feature-intro {
+		font-family: var(--font-body);
+		font-size: var(--p-s-size);
+		font-weight: var(--text-font-weight);
+		line-height: var(--p-s-line-height);
+		max-width: var(--p-s-max-width);
+		text-align: left;
+	}
+
+	.feature-intro :global(p) {
+		font: inherit;
+		max-width: inherit;
+		margin: 0 0 1rem;
+	}
+
+	.feature-intro :global(ul),
+	.feature-intro :global(ol) {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		margin: 1rem 0 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.feature-intro :global(li) {
+		font: inherit;
+		position: relative;
+		padding-left: 1.75rem;
+	}
+
+	.feature-intro :global(li p) {
+		margin: 0;
+	}
+
+	.feature-intro :global(li::before) {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 0.35rem;
+		width: 17px;
+		height: 17px;
+		background-image: url('/check-circle.svg');
+		background-size: contain;
+		background-repeat: no-repeat;
 	}
 
 	.feature-list {

--- a/src/lib/server/contentService.test.js
+++ b/src/lib/server/contentService.test.js
@@ -60,7 +60,7 @@ describe('ContentService property-based tests', () => {
 	})
 
 	it('rejects unknown content types for any non-whitelisted string', async () => {
-		const knownTypes = new Set(['documents', 'categories', 'themes', 'events', 'cooperations', 'news', 'nominations', 'faqs'])
+		const knownTypes = new Set(['documents', 'categories', 'themes', 'events', 'cooperations', 'news', 'nominations', 'faqs', 'lados', 'courses', 'sectoralAdvisoryBoards', 'pageHome'])
 
 		await fc.assert(
 			fc.asyncProperty(

--- a/src/lib/server/strategies/directusContentStrategy.js
+++ b/src/lib/server/strategies/directusContentStrategy.js
@@ -17,7 +17,8 @@ const COLLECTIONS = {
 	faqs: { path: 'adconnect_faqs', key: 'id' },
 	lados: { path: 'adconnect_lados', key: 'id' },
 	courses: { path: 'adconnect_courses', key: 'id' },
-	sectoralAdvisoryBoards: { path: 'adconnect_sectoral_advisory_boards', key: 'id' }
+	sectoralAdvisoryBoards: { path: 'adconnect_sectoral_advisory_boards', key: 'id' },
+	pageHome: { path: 'adconnect_page_home', key: 'id' }
 }
 
 function getConfig(contentType) {

--- a/src/routes/(public)/+page.server.js
+++ b/src/routes/(public)/+page.server.js
@@ -1,15 +1,53 @@
 import { ContentService } from '$lib/server/contentService'
 
+const homePageFields = [
+	'id',
+	'hero_heading',
+	'hero_body',
+	'hero_primary_button_text',
+	'hero_primary_button_url',
+	'hero_secondary_button_text',
+	'hero_secondary_button_url',
+	'intro_heading',
+	'intro_body',
+	'intro_button_text',
+	'intro_button_url',
+	'cards_heading',
+	'cards_intro',
+	'card_1_title',
+	'card_1_body',
+	'card_1_button_text',
+	'card_1_button_url',
+	'card_2_title',
+	'card_2_body',
+	'card_2_button_text',
+	'card_2_button_url',
+	'card_3_title',
+	'card_3_body',
+	'card_3_button_text',
+	'card_3_button_url',
+	'why_heading',
+	'why_body',
+	'why_button_text',
+	'why_button_url'
+].join(',')
+
 export async function load() {
 	// Requested fields for the data from Directus API
 	const newsFields = 'title,description,date_updated,uuid,hero'
 	const cooperationFields = 'id,url,name,logo'
 
 	// Fetch the content data via the ContentService.
-	const newsResponse = await ContentService.fetchContent('news', null, newsFields, null, false)
-	const cooperationResponse = await ContentService.fetchContent('cooperations', null, cooperationFields, null, false)
+	const [homePageResponse, newsResponse, cooperationResponse] = await Promise.all([
+		ContentService.fetchContent('pageHome', null, homePageFields, null, false),
+		ContentService.fetchContent('news', null, newsFields, null, false),
+		ContentService.fetchContent('cooperations', null, cooperationFields, null, false)
+	])
+
+	const homePageItem = homePageResponse.data.pageHome?.[0]
 
 	return {
+		homePage: homePageItem ?? {},
 		news: Array.from(newsResponse.data.news.values()),
 		cooperation: Array.from(cooperationResponse.data.cooperations.values())
 	}

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -1,6 +1,4 @@
 <script>
-	import placeholder from '$lib/assets/placeholder-hero.webp'
-
 	// Import components
 	import { MultipleFaq, SingleFaq, DividerText, Divider, LogoSection, Hero, NewsCardSection, Information, InformationCards, FeatureSplit, Link } from '$lib'
 
@@ -8,8 +6,30 @@
 	import { zaal } from '$lib'
 
 	const { data } = $props()
-	const { news } = data
-	const { cooperation } = data
+	const news = $derived(data.news ?? [])
+	const cooperation = $derived(data.cooperation ?? [])
+	const homePage = $derived(data.homePage ?? {})
+
+	const informationCards = $derived([
+		{
+			title: homePage.card_1_title,
+			description: homePage.card_1_body,
+			buttonText: homePage.card_1_button_text,
+			buttonLink: homePage.card_1_button_url
+		},
+		{
+			title: homePage.card_2_title,
+			description: homePage.card_2_body,
+			buttonText: homePage.card_2_button_text,
+			buttonLink: homePage.card_2_button_url
+		},
+		{
+			title: homePage.card_3_title,
+			description: homePage.card_3_body,
+			buttonText: homePage.card_3_button_text,
+			buttonLink: homePage.card_3_button_url
+		}
+	])
 </script>
 
 <svelte:head>
@@ -17,18 +37,18 @@
 </svelte:head>
 
 <Hero
-	title="Het landelijke platform voor Associate degrees"
-	description="Ad-netwerk samen om kennis te delen, samen te werken en de kwaliteit en zichtbaarheid van Associate degrees te versterken."
+	title={homePage.hero_heading}
+	description={homePage.hero_body}
 >
 	<Link
 		slot="secondary"
-		href="/ad-dag"
-		class="button-outline-white">Kom naar de Ad-dag</Link
+		href={homePage.hero_secondary_button_url}
+		class="button-outline-white">{homePage.hero_secondary_button_text}</Link
 	>
 	<Link
 		slot="primary"
-		href="/over-ad"
-		class="button-outline-blue">Meer over Ad's</Link
+		href={homePage.hero_primary_button_url}
+		class="button-outline-blue">{homePage.hero_primary_button_text}</Link
 	>
 	<img
 		class="hero-image"
@@ -40,40 +60,20 @@
 	/>
 </Hero>
 
-<NewsCardSection news={data.news.slice(0, 3)} />
+<NewsCardSection news={news.slice(0, 3)} />
 
 <Information
-	title="Wat zijn Associate degrees en hoe sluit het aan bij jou wensen?"
-	description="Associate degrees zijn tweejarige hbo-opleidingen die sterk praktijkgericht zijn en direct aansluiten op de arbeidsmarkt. Ze combineren werken en leren en zijn bedoeld voor studenten die zich willen ontwikkelen op hbo-niveau, zonder direct een vierjarige bachelor te volgen. De opleidingen worden samen met het werkveld vormgegeven en spelen in op actuele beroepsvragen. Hierdoor doe je relevante kennis en vaardigheden op die je meteen kunt toepassen in de praktijk. Een Associate degree biedt daarnaast flexibiliteit: je behaalt een zelfstandig diploma en kunt, als je dat wilt, doorstromen naar een bacheloropleiding."
-	buttonText="Meer info over Ad's"
-	buttonLink="#"
+	title={homePage.intro_heading}
+	description={homePage.intro_body}
+	buttonText={homePage.intro_button_text}
+	buttonLink={homePage.intro_button_url}
 	imageAlt="Studenten ontvangen award"
 />
 
 <InformationCards
-	heading="Ontdek het Ad‑onderwijs"
-	intro="Leer alles over Associate degrees, doorstroommogelijkheden en netwerkevenementen.
-Blijf op de hoogte van Ad‑opleidingen en activiteiten binnen het overlegplatform."
-	items={[
-		{
-			title: 'Doorstroom Ad',
-			description: 'Met een Associate degree stroom je door naar het derde jaar van een bachelor. Zo combineer je praktijk met een diploma.',
-			buttonText: "Meer over doorstroom Ad's",
-			buttonLink: '/over-ad/doorstroom-ad-bachelor'
-		},
-		{
-			title: 'Ad-dag',
-			description: 'De jaarlijkse Ad‑dag brengt studenten, docenten en werkveldpartners samen. Tijdens workshops staat kennisdeling en netwerken centraal.',
-			buttonText: 'Meer over de Ad-dag',
-			buttonLink: '/ad-dag'
-		},
-		{
-			title: 'Ad-talent Award',
-			description: 'Jaarlijks wordt door het Overlegplatform de Ad Talent Award uitgereikt, waarmee 2 Associate degree-talenten verkozen worden.',
-			buttonText: 'Meer over Talent Awards',
-			buttonLink: '/talent-award'
-		}
-	]}
+	heading={homePage.cards_heading}
+	intro={homePage.cards_intro}
+	items={informationCards}
 />
 
 <section class="logo-section">
@@ -83,11 +83,11 @@ Blijf op de hoogte van Ad‑opleidingen en activiteiten binnen het overlegplatfo
 </section>
 
 <FeatureSplit
-	title="Waarom kiezen voor een Associate degree?"
-	intro="Een Associate degree combineert praktijkgericht onderwijs met doorstroommogelijkheden, zodat je snel ervaring opdoet én een diploma haalt."
+	title={homePage.why_heading}
+	intro={homePage.why_body}
 	bullets={['Praktijkgericht leren en direct vaardigheden toepassen', 'Korte studieduur van 2 jaar', 'Doorstromen naar een bacheloropleiding mogelijk']}
-	ctaText="Meer over Associate degrees"
-	ctaLink="/over-ad"
+	ctaText={homePage.why_button_text}
+	ctaLink={homePage.why_button_url}
 	imageSrc="/images/award.jpg"
 	imageAlt="Studenten bij AdTalent award"
 />

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -85,7 +85,6 @@
 <FeatureSplit
 	title={homePage.why_heading}
 	intro={homePage.why_body}
-	bullets={['Praktijkgericht leren en direct vaardigheden toepassen', 'Korte studieduur van 2 jaar', 'Doorstromen naar een bacheloropleiding mogelijk']}
 	ctaText={homePage.why_button_text}
 	ctaLink={homePage.why_button_url}
 	imageSrc="/images/award.jpg"


### PR DESCRIPTION
## What does this change?

Resolves issue #650 

Bepaalde tekst content op de home pagina, wordt nu dynamisch opgehaald vanuit de betreffende directus collectie. Beheerders kunnen nu via directus deze data bewerken.

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. ga naar deze branch
2. Open de home pagina
3. Ga naar directus
4. Edit een tekst veld in directus 
5. Check op de home pagina of deze daadwerkelijk is veranderd
