### PR TITLE
feat: adds faq page, now fetches faq's from database.

### DIFF
--- a/src/lib/organisms/TopNav.svelte
+++ b/src/lib/organisms/TopNav.svelte
@@ -5,7 +5,7 @@
 <nav aria-label="Secundair">
 	<section class="nav-right">
 		<ul>
-			<li><a href="/#faq">FAQ's</a></li>
+			<li><a href="/faq">FAQ's</a></li>
 			<li>
 				<a
 					class={page.url.pathname === '/over-ons' ? 'active' : 'menu-button'}

--- a/src/routes/(public)/+page.server.js
+++ b/src/routes/(public)/+page.server.js
@@ -4,13 +4,19 @@ export async function load() {
 	// Requested fields for the data from Directus API
 	const newsFields = 'title,description,date_updated,uuid,hero'
 	const cooperationFields = 'id,url,name,logo'
+	const faqFields = 'id,question,answer,important'
+
+	// Important faq filter
+	const faqFilters = { important: { _eq: true } }
 
 	// Fetch the content data via the ContentService.
 	const newsResponse = await ContentService.fetchContent('news', null, newsFields, null, false)
 	const cooperationResponse = await ContentService.fetchContent('cooperations', null, cooperationFields, null, false)
+	const faqResponse = await ContentService.fetchContent('faqs', null, faqFields, faqFilters, false)
 
 	return {
 		news: Array.from(newsResponse.data.news.values()),
-		cooperation: Array.from(cooperationResponse.data.cooperations.values())
+		cooperations: Array.from(cooperationResponse.data.cooperations.values()),
+		faqs: Array.from(faqResponse.data.faqs.values())
 	}
 }

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -1,15 +1,15 @@
 <script>
-	import placeholder from '$lib/assets/placeholder-hero.webp'
-
 	// Import components
 	import { MultipleFaq, SingleFaq, DividerText, Divider, LogoSection, Hero, NewsCardSection, Information, InformationCards, FeatureSplit, Link } from '$lib'
 
 	// Import images
 	import { zaal } from '$lib'
 
-	const { data } = $props()
-	const { news } = data
-	const { cooperation } = data
+	const props = $props()
+	const data = $derived(props.data)
+	const news = $derived(data.news)
+	const cooperations = $derived(data.cooperations)
+	const faqs = $derived(data.faqs)
 </script>
 
 <svelte:head>
@@ -40,7 +40,7 @@
 	/>
 </Hero>
 
-<NewsCardSection news={data.news.slice(0, 3)} />
+<NewsCardSection news={news.slice(0, 3)} />
 
 <Information
 	title="Wat zijn Associate degrees en hoe sluit het aan bij jou wensen?"
@@ -78,7 +78,7 @@ Blijf op de hoogte van Ad‑opleidingen en activiteiten binnen het overlegplatfo
 
 <section class="logo-section">
 	<DividerText text="Partijen waarmee wij samenwerken" />
-	<LogoSection {cooperation} />
+	<LogoSection {cooperations} />
 	<Divider />
 </section>
 
@@ -97,28 +97,14 @@ Blijf op de hoogte van Ad‑opleidingen en activiteiten binnen het overlegplatfo
 	id="faq"
 >
 	<h2>Veelgestelde vragen</h2>
-
 	<MultipleFaq>
-		<SingleFaq
-			open={true}
-			question="Wat is een Associate degree?"
-			answer="Een Associate Degree is een praktijkgerichte, tweejarige opleiding op hbo-niveau. De opleiding combineert theoretische kennis met praktische ervaring, zodat studenten snel inzetbaar zijn in het werkveld en de mogelijkheid hebben om door te stromen naar een bacheloropleiding."
-		/>
-
-		<SingleFaq
-			question="Hoe lang duurt een Associate degree?"
-			answer="Een Ad duurt doorgaans twee jaar bij een voltijdopleiding. Bij deeltijd kan dit langer zijn, afhankelijk van de persoonlijke planning en werkervaring."
-		/>
-
-		<SingleFaq
-			question="Wat is het verschil tussen een Associate degree en een Bachelor?"
-			answer="Een bacheloropleiding duurt meestal vier jaar en richt zich breder op theorie en verdieping, terwijl een Ad intensief, praktijkgericht en korter is, met direct toepasbare vaardigheden voor het werkveld."
-		/>
-
-		<SingleFaq
-			question="Welke voordelen heeft het behalen van een Associate degree?"
-			answer="Met een Ad-diploma ben je snel inzetbaar in de praktijk, heb je een erkend hbo-kwalificatieniveau en kun je doorstromen naar een bachelor. Daarnaast vergroot het je carrièremogelijkheden en professionele netwerk."
-		/>
+		{#each faqs as faq, index (faq.id)}
+			<SingleFaq
+				open={index === 0}
+				question={faq.question}
+				answer={faq.answer}
+			/>
+		{/each}
 	</MultipleFaq>
 </section>
 

--- a/src/routes/(public)/faq/+page.server.js
+++ b/src/routes/(public)/faq/+page.server.js
@@ -1,0 +1,10 @@
+import { ContentService } from '$lib/server/contentService'
+
+export async function load() {
+	const faqFields = 'id,question,answer,important'
+	const faqResponse = await ContentService.fetchContent('faqs', null, faqFields, null, false)
+
+	return {
+		faqs: Array.from(faqResponse.data.faqs.values())
+	}
+}

--- a/src/routes/(public)/faq/+page.svelte
+++ b/src/routes/(public)/faq/+page.svelte
@@ -1,0 +1,47 @@
+<script>
+	// Import components
+	import { MultipleFaq, SingleFaq } from '$lib'
+
+	const props = $props()
+	const data = $derived(props.data)
+	const faqs = $derived(data.faqs)
+</script>
+
+<section
+	class="faq-section"
+	id="faq"
+>
+	<h2>Veelgestelde vragen</h2>
+	<MultipleFaq>
+		{#each faqs as faq, index (faq.id)}
+			<SingleFaq
+				open={index === 0}
+				question={faq.question}
+				answer={faq.answer}
+			/>
+		{/each}
+	</MultipleFaq>
+</section>
+
+<style>
+	.faq-section {
+		display: flex;
+		flex-direction: column;
+		gap: 2em;
+		padding: 3em 5%;
+		box-sizing: border-box;
+		position: relative;
+
+		@media (min-width: 768px) {
+			padding: 2em 5em 5em 5em;
+		}
+	}
+
+	.faq-section h2 {
+		text-align: center;
+	}
+
+	#faq {
+		scroll-margin-top: 150px;
+	}
+</style>


### PR DESCRIPTION
## What does this change?

Resolves issue #647 from userstory #649

This PR adds a specialized FAQ page for FAQ's marked as non important.
Also now fetches all faq's from the database instead of being hardcoded in the html.

## How Has This Been Tested?

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## How to review

1. Open and run this branch.
2. Navigate to the FAQ section on the homepage and verify if they are being rendered correctly.
3. Set a FAQ's status to concept in the database.
4. Verify that question is now no longer being rendered.
5. Navigate to the FAQ page.
6. Verify it renders all FAQ's (including the ones not marked as important).