### PR TITLE
602 organism event section

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -129,3 +129,4 @@ export { default as RDetailsSection } from './refactored/organisms/DetailsSectio
 // organisms
 export { default as RSectionHero } from './refactored/organisms/SectionHero.svelte'
 export { default as RSectionPage } from './refactored/organisms/SectionPage.svelte'
+export { default as RSectionPlanning } from './refactored/organisms/SectionPlanning.svelte'

--- a/src/lib/refactored/molecules/TimeTable.svelte
+++ b/src/lib/refactored/molecules/TimeTable.svelte
@@ -1,34 +1,5 @@
 <script>
-	// TODO: schedule data that needs to be added to directus
-	const scheduleData = {
-		schedule: [
-			{
-				startTime: '09:30',
-				endTime: '10:00',
-				event: 'Inloop met koffie/thee'
-			},
-			{
-				startTime: '10:00',
-				endTime: '13:00',
-				event: 'Opening, keynote, gesprekken en Ad Talent Award'
-			},
-			{
-				startTime: '13:00',
-				endTime: '13:45',
-				event: 'Lunch'
-			},
-			{
-				startTime: '13:45',
-				endTime: '15:30',
-				event: 'Workshops en excursies'
-			},
-			{
-				startTime: '15:30',
-				endTime: '17:00',
-				event: 'Borrel & ontmoeting'
-			}
-		]
-	}
+	const { scheduleData } = $props()
 </script>
 
 <ul class="schedule__list">

--- a/src/lib/refactored/organisms/SectionPlanning.svelte
+++ b/src/lib/refactored/organisms/SectionPlanning.svelte
@@ -1,8 +1,8 @@
 <script>
-	import { RCardSection, RTimeTable } from '$lib'
+	import { RCardSection, RTimeTable, RLink } from '$lib'
 	import { IconDots } from '$lib/icons'
 
-	const { sectionInfo, programInfo, workshopInfo } = $props()
+	const { sectionInfo, cardsData } = $props()
 </script>
 
 <section>
@@ -12,35 +12,28 @@
 	/>
 
 	<section class="cards">
-		<article class="card">
-			<div class="wrapper-text">
-				<IconDots variant="heading-three" />
-				<h3>Programma</h3>
-			</div>
+		{#each cardsData as card (card.id)}
+			<article class="card">
+				<div class="wrapper-text">
+					<IconDots variant="heading-three" />
+					<h3>{card.title}</h3>
+				</div>
 
-			<RTimeTable scheduleData={programInfo.schedule} />
+				{#if card.description}
+					<p>
+						{card.description}
+					</p>
+				{:else if card.schedule}
+					<RTimeTable scheduleData={card.schedule} />
+				{/if}
 
-			<a
-				class="button-outline-blue"
-				href={programInfo.link.href}
-				>{programInfo.link.label}
-			</a>
-		</article>
-
-		<article class="card">
-			<div class="wrapper-text">
-				<IconDots variant="heading-three" />
-				<h3>Workshops</h3>
-			</div>
-			<p>
-				{workshopInfo.description}
-			</p>
-			<a
-				class="button-outline-blue"
-				href={workshopInfo.link.href}
-				>{workshopInfo.link.label}
-			</a>
-		</article>
+				<RLink
+					class="button-outline-blue"
+					href={card.link.href}
+					>{card.link.label}
+				</RLink>
+			</article>
+		{/each}
 	</section>
 </section>
 

--- a/src/lib/refactored/organisms/SectionPlanning.svelte
+++ b/src/lib/refactored/organisms/SectionPlanning.svelte
@@ -1,0 +1,118 @@
+<script>
+	import { RCardSection, RTimeTable } from '$lib'
+	import { IconDots } from '$lib/icons'
+
+	const { sectionInfo, programInfo, workshopInfo } = $props()
+</script>
+
+<section>
+	<RCardSection
+		title={sectionInfo.title}
+		description={sectionInfo.description}
+	/>
+
+	<section class="cards">
+		<article class="card">
+			<div class="wrapper-text">
+				<IconDots variant="heading-three" />
+				<h3>Programma</h3>
+			</div>
+
+			<RTimeTable scheduleData={programInfo.schedule} />
+
+			<a
+				class="button-outline-blue"
+				href={programInfo.link.href}
+				>{programInfo.link.label}
+			</a>
+		</article>
+
+		<article class="card">
+			<div class="wrapper-text">
+				<IconDots variant="heading-three" />
+				<h3>Workshops</h3>
+			</div>
+			<p>
+				{workshopInfo.description}
+			</p>
+			<a
+				class="button-outline-blue"
+				href={workshopInfo.link.href}
+				>{workshopInfo.link.label}
+			</a>
+		</article>
+	</section>
+</section>
+
+<style>
+	.cards {
+		display: grid;
+		grid-template-columns: 1fr;
+		grid-template-rows: repeat(4, auto);
+		margin-top: 5em;
+		gap: 1em;
+		margin-bottom: 2em;
+
+		article {
+			border: 1px solid #cccccc;
+			border-radius: 1em;
+			padding: 2em;
+			transition: 0.2s ease-in-out;
+			display: flex;
+			flex-direction: column;
+			gap: 1em;
+			background-color: light-dark(var(--text-white), hsl(210, 30%, 8%));
+			text-align: center;
+			margin: 0 auto;
+
+			p {
+				max-width: 500px;
+			}
+
+			&:hover {
+				border: 1px solid #00408d;
+				box-shadow: 0 3px 10px rgba(141, 141, 141, 0.2);
+				translate: 0 -1%;
+				transition: 0.2s ease-in-out;
+			}
+		}
+
+		h2 {
+			color: var(--primary-blue);
+		}
+	}
+
+	.card {
+		display: grid;
+		grid-template-rows: subgrid;
+		grid-row: span 4;
+		border: 1px solid var(--text-white);
+		background-color: var(--text-white);
+		color: light-dark(var(--primary-blue), var(--text-white));
+		border-radius: 24px;
+		padding: 2em;
+
+		.logo {
+			margin: 0;
+			text-align: left;
+			float: left;
+		}
+		h2 {
+			margin-top: 0;
+			margin-bottom: 0.5em;
+			right: 1em;
+			position: relative;
+		}
+	}
+
+	a {
+		margin-top: 1em;
+		align-self: center;
+	}
+	@media (min-width: 1024px) {
+		.cards {
+			grid-template-columns: repeat(2, 1fr);
+			gap: 0.5em;
+		}
+	}
+</style>

--- a/src/lib/refactored/organisms/SectionPlanning.svelte
+++ b/src/lib/refactored/organisms/SectionPlanning.svelte
@@ -54,12 +54,11 @@
 
 		@media (min-width: 1024px) {
 			grid-template-columns: repeat(2, 1fr);
-			gap: 5em;
 		}
 	}
 
 	.card {
-		--_border-color: #cccccc;
+		--_border-color: hsl(0, 0%, 80%);
 
 		display: flex;
 		flex-direction: column;

--- a/src/lib/refactored/organisms/SectionPlanning.svelte
+++ b/src/lib/refactored/organisms/SectionPlanning.svelte
@@ -5,24 +5,23 @@
 	const { sectionInfo, cardsData } = $props()
 </script>
 
-<section>
+<section class="card-section">
 	<RCardSection
 		title={sectionInfo.title}
 		description={sectionInfo.description}
 	/>
 
-	<section class="cards">
+	<div class="card-section__list">
+
 		{#each cardsData as card (card.id)}
 			<article class="card">
-				<div class="wrapper-text">
+				<div class="card__header">
 					<IconDots variant="heading-three" />
-					<h3>{card.title}</h3>
+					<h3 class="card__title">{card.title}</h3>
 				</div>
 
 				{#if card.description}
-					<p>
-						{card.description}
-					</p>
+					<p class="card__text">{card.description}</p>
 				{:else if card.schedule}
 					<RTimeTable scheduleData={card.schedule} />
 				{/if}
@@ -30,82 +29,66 @@
 				<RLink
 					class="button-outline-blue"
 					href={card.link.href}
-					>{card.link.label}
+				>
+					{card.link.label}
 				</RLink>
 			</article>
 		{/each}
-	</section>
+
+	</div>
 </section>
 
 <style>
-	.cards {
+	.card-section {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		margin: 5em min(5%, 3em);
+	}
+
+	.card-section__list {
 		display: grid;
 		grid-template-columns: 1fr;
-		grid-template-rows: repeat(4, auto);
-		margin-top: 5em;
-		gap: 1em;
-		margin-bottom: 2em;
+		gap: 5em;
+		margin: 5em 0;
 
-		article {
-			border: 1px solid #cccccc;
-			border-radius: 1em;
-			padding: 2em;
-			transition: 0.2s ease-in-out;
-			display: flex;
-			flex-direction: column;
-			gap: 1em;
-			background-color: light-dark(var(--text-white), hsl(210, 30%, 8%));
-			text-align: center;
-			margin: 0 auto;
-
-			p {
-				max-width: 500px;
-			}
-
-			&:hover {
-				border: 1px solid #00408d;
-				box-shadow: 0 3px 10px rgba(141, 141, 141, 0.2);
-				translate: 0 -1%;
-				transition: 0.2s ease-in-out;
-			}
-		}
-
-		h2 {
-			color: var(--primary-blue);
+		@media (min-width: 1024px) {
+			grid-template-columns: repeat(2, 1fr);
+			gap: 5em;
 		}
 	}
 
 	.card {
-		display: grid;
-		grid-template-rows: subgrid;
-		grid-row: span 4;
-		border: 1px solid var(--text-white);
-		background-color: var(--text-white);
-		color: light-dark(var(--primary-blue), var(--text-white));
-		border-radius: 24px;
+		--_border-color: #cccccc;
+
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1em;
 		padding: 2em;
+		border: 1px solid var(--_border-color);
+		border-radius: 1em;
+		background-color: light-dark(var(--text-white), hsl(210, 30%, 8%));
+		color: light-dark(var(--primary-blue), var(--text-white));
+		max-width: 600px;
 
-		.logo {
-			margin: 0;
-			text-align: left;
-			float: left;
-		}
-		h2 {
-			margin-top: 0;
-			margin-bottom: 0.5em;
-			right: 1em;
-			position: relative;
+		transition: 0.2s ease-in-out;
+
+		&:hover {
+			--_border-color: #00408d;
+			box-shadow: 0 3px 10px rgba(141, 141, 141, 0.2);
+			translate: 0 -1%;
 		}
 	}
 
-	a {
-		margin-top: 1em;
-		align-self: center;
+	.card__header {
+		display: flex;
+		gap: 2em;
+		align-self: start;
 	}
-	@media (min-width: 1024px) {
-		.cards {
-			grid-template-columns: repeat(2, 1fr);
-			gap: 0.5em;
-		}
+
+	.card__text {
+		max-width: 500px;
+		margin-bottom: auto;
 	}
 </style>

--- a/src/routes/(public)/ad-dag/+page.svelte
+++ b/src/routes/(public)/ad-dag/+page.svelte
@@ -4,7 +4,38 @@
 	// Import images
 	import { addag1, addag2, addag3 } from '$lib'
 
-	import { MultipleFaq, SingleFaq, Hero, Addag, Location, Schedule, RSectionHero, RPicture, RSectionPage } from '$lib'
+	import { MultipleFaq, SingleFaq, Hero, Addag, Location, Schedule, RSectionHero, RPicture, RSectionPage, RSectionPlanning } from '$lib'
+
+	// TODO: schedule data that needs to be added to directus
+	const scheduleData = {
+		schedule: [
+			{
+				startTime: '09:30',
+				endTime: '10:00',
+				event: 'Inloop met koffie/thee'
+			},
+			{
+				startTime: '10:00',
+				endTime: '13:00',
+				event: 'Opening, keynote, gesprekken en Ad Talent Award'
+			},
+			{
+				startTime: '13:00',
+				endTime: '13:45',
+				event: 'Lunch'
+			},
+			{
+				startTime: '13:45',
+				endTime: '15:30',
+				event: 'Workshops en excursies'
+			},
+			{
+				startTime: '15:30',
+				endTime: '17:00',
+				event: 'Borrel & ontmoeting'
+			}
+		]
+	}
 </script>
 
 <svelte:head>
@@ -83,7 +114,24 @@
 		/>
 	</div>
 </section>
-<Schedule />
+
+<RSectionPlanning
+	sectionInfo={{
+		title: 'Planning',
+		description:
+			'Beleef de Landelijke Ad‑dag! De Landelijke Ad‑dag belooft een bruisende dag vol inspiratie, ontmoetingen en praktijkvoorbeelden te worden. Geleid door Maikel van Duinen, radiotalent en docent, word je meegenomen in een energieke dag vol boeiende sessies, waaronder een keynote over de maatschappelijke en economische impact van de Ad, inspirerende gesprekken tussen onderwijs, werkveld en studenten, de feestelijke uitreiking van de Ad Talent Award, workshops en excursies om de impact van Ad‑studenten van dichtbij te ervaren, en optredens met volop gelegenheid om elkaar te ontmoeten.'
+	}}
+	programInfo={{
+		schedule: scheduleData,
+		link: { label: "Bekijk Programma", href: '#' }
+	}}
+	workshopInfo={{
+		description:
+			'Tijdens de Landelijke Ad‑dag worden verschillende workshops georganiseerd waarin deelnemers samen leren, ervaringen delen en praktische handvatten krijgen op thema’s zoals diversiteit, professionalisering, inzet van technologie binnen Ad‑onderwijs, loopbaanontwikkeling, duurzaamheid en samenwerking met werkveld en onderwijs. De precieze workshoptitels en inhoud worden jaarlijks aangepast en zijn onderdeel van het programma',
+		link: { label: "Bekijk workshops", href: '#' }
+	}}
+/>
+
 <Location />
 
 <style>

--- a/src/routes/(public)/ad-dag/+page.svelte
+++ b/src/routes/(public)/ad-dag/+page.svelte
@@ -121,15 +121,19 @@
 		description:
 			'Beleef de Landelijke Ad‑dag! De Landelijke Ad‑dag belooft een bruisende dag vol inspiratie, ontmoetingen en praktijkvoorbeelden te worden. Geleid door Maikel van Duinen, radiotalent en docent, word je meegenomen in een energieke dag vol boeiende sessies, waaronder een keynote over de maatschappelijke en economische impact van de Ad, inspirerende gesprekken tussen onderwijs, werkveld en studenten, de feestelijke uitreiking van de Ad Talent Award, workshops en excursies om de impact van Ad‑studenten van dichtbij te ervaren, en optredens met volop gelegenheid om elkaar te ontmoeten.'
 	}}
-	programInfo={{
-		schedule: scheduleData,
-		link: { label: "Bekijk Programma", href: '#' }
-	}}
-	workshopInfo={{
-		description:
-			'Tijdens de Landelijke Ad‑dag worden verschillende workshops georganiseerd waarin deelnemers samen leren, ervaringen delen en praktische handvatten krijgen op thema’s zoals diversiteit, professionalisering, inzet van technologie binnen Ad‑onderwijs, loopbaanontwikkeling, duurzaamheid en samenwerking met werkveld en onderwijs. De precieze workshoptitels en inhoud worden jaarlijks aangepast en zijn onderdeel van het programma',
-		link: { label: "Bekijk workshops", href: '#' }
-	}}
+	cardsData={[
+		{
+			title: 'Programma',
+			schedule: scheduleData,
+			link: { label: 'Bekijk Programma', href: '#' }
+		},
+		{
+			title: 'Workshops',
+			description:
+				'Tijdens de Landelijke Ad‑dag worden verschillende workshops georganiseerd waarin deelnemers samen leren, ervaringen delen en praktische handvatten krijgen op thema’s zoals diversiteit, professionalisering, inzet van technologie binnen Ad‑onderwijs, loopbaanontwikkeling, duurzaamheid en samenwerking met werkveld en onderwijs. De precieze workshoptitels en inhoud worden jaarlijks aangepast en zijn onderdeel van het programma',
+			link: { label: 'Bekijk workshops', href: '#' }
+		}
+	]}
 />
 
 <Location />


### PR DESCRIPTION
## What does this change?

Resolves issue #602

This PR has the code for the planning section on the ad-dag page:
- reused old code, and prevented duplicate HTML by using an each loop
- all data is send from the +page.svelte into this component and its sub components
- used refactored components for the link and time table

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images
old:  
<img width="2553" height="1416" alt="image" src="https://github.com/user-attachments/assets/95dc10e7-bd3b-44ad-9613-09bba5a3301a" />  
<details>
<summary>bigger screen:</summary>

<img width="2112" height="944" alt="image" src="https://github.com/user-attachments/assets/cfbce692-44f4-4263-a46c-f6ac1cd168d5" />
</details>


new:  
<img width="1564" height="1048" alt="image" src="https://github.com/user-attachments/assets/bc1bd307-5f50-4ba5-a614-16c5e33b9b5a" />
- used `CardSection` component for the section title and description, making it consistant across the website
- reworked the gap between cards, preventing it from becoming to wide on bigger screens


## How to review
Open ad-dag page to see this section
- Check the responsive behavior
- check if the content is loaded correct
- look at the code, is it understandable?
