### PR TITLE
674 feature content lado pagina dynamisch ophalen

### DIFF
--- a/src/lib/server/contentService.test.js
+++ b/src/lib/server/contentService.test.js
@@ -60,7 +60,22 @@ describe('ContentService property-based tests', () => {
 	})
 
 	it('rejects unknown content types for any non-whitelisted string', async () => {
-		const knownTypes = new Set(['documents', 'categories', 'themes', 'events', 'cooperations', 'news', 'nominations', 'faqs', 'lados', 'courses', 'sectoralAdvisoryBoards', 'pageHome', 'pageAboutAd'])
+		const knownTypes = new Set([
+			'documents',
+			'categories',
+			'themes',
+			'events',
+			'cooperations',
+			'news',
+			'nominations',
+			'faqs',
+			'lados',
+			'courses',
+			'sectoralAdvisoryBoards',
+			'pageHome',
+			'pageAboutAd',
+			'pageLado'
+		])
 
 		await fc.assert(
 			fc.asyncProperty(

--- a/src/lib/server/strategies/directusContentStrategy.js
+++ b/src/lib/server/strategies/directusContentStrategy.js
@@ -19,7 +19,8 @@ const COLLECTIONS = {
 	courses: { path: 'adconnect_courses', key: 'id' },
 	sectoralAdvisoryBoards: { path: 'adconnect_sectoral_advisory_boards', key: 'id' },
 	pageHome: { path: 'adconnect_page_home', key: 'id' },
-	pageAboutAd: { path: 'adconnect_page_about_ad', key: 'id' }
+	pageAboutAd: { path: 'adconnect_page_about_ad', key: 'id' },
+	pageLado: { path: 'adconnect_page_lado', key: 'id' }
 }
 
 function getConfig(contentType) {

--- a/src/routes/(public)/lados-en-ad-profielen/+page.server.js
+++ b/src/routes/(public)/lados-en-ad-profielen/+page.server.js
@@ -3,6 +3,24 @@ import { ContentService } from '$lib/server/contentService.js'
 const LADO_FIELDS = 'id,title,national_ad_profile,lado_status,contact_persons,status,parent,sectoral_advisory_board'
 const COURSE_FIELDS = 'id,title,lado,cooperations.adconnect_cooperation_id.id,cooperations.adconnect_cooperation_id.name,cooperations.adconnect_cooperation_id.url'
 const SECTORAL_ADVISORY_BOARD_FIELDS = 'id,title'
+const LADO_PAGE_FIELDS = [
+	'id',
+	'hero_heading',
+	'hero_body',
+	'hero_primary_button_text',
+	'hero_primary_button_url',
+	'hero_secondary_button_text',
+	'hero_secondary_button_url',
+	'lado_section_heading',
+	'lado_card_1_title',
+	'lado_card_1_body',
+	'lado_card_2_title',
+	'lado_card_2_body',
+	'lado_card_3_title',
+	'lado_card_3_body',
+	'lado_card_4_title',
+	'lado_card_4_body'
+].join(',')
 const PUBLISHED_FILTER = { status: { _eq: 'published' } }
 const LOAD_ERROR = `Er is een probleem opgetreden bij het ophalen van de LAdO's.`
 
@@ -38,7 +56,12 @@ function getCourseCooperations(course) {
 }
 
 export async function load() {
-	const ladosResponse = await ContentService.fetchContent('lados', null, LADO_FIELDS, PUBLISHED_FILTER, false)
+	const [ladoPageResponse, ladosResponse] = await Promise.all([
+		ContentService.fetchContent('pageLado', null, LADO_PAGE_FIELDS, null, false),
+		ContentService.fetchContent('lados', null, LADO_FIELDS, PUBLISHED_FILTER, false)
+	])
+
+	const ladoPageItem = ladoPageResponse.data.pageLado?.[0]
 	const ladoItems = ladosResponse.data.lados ?? []
 	const ladoIds = getUniqueIds(ladoItems, (lado) => lado.id)
 	const sectoralAdvisoryBoardIds = getUniqueIds(ladoItems, (lado) => getRelationId(lado.sectoral_advisory_board))
@@ -66,6 +89,7 @@ export async function load() {
 		.sort((a, b) => (a.title ?? '').localeCompare(b.title ?? '', 'nl', { numeric: true }))
 
 	return {
+		ladoPage: ladoPageItem ?? {},
 		lados,
 		loadError: hasErrors(ladosResponse, coursesResponse, sectoralAdvisoryBoardsResponse) ? LOAD_ERROR : null
 	}

--- a/src/routes/(public)/lados-en-ad-profielen/+page.svelte
+++ b/src/routes/(public)/lados-en-ad-profielen/+page.svelte
@@ -2,28 +2,26 @@
 	import { Hero, LadoInfoCard, LadosOverview, overleggen } from '$lib'
 
 	const { data } = $props()
+	const ladoPage = $derived(data.ladoPage ?? {})
 
-	const infoCards = [
+	const infoCards = $derived([
 		{
-			title: 'Gezamenlijke profilering van vergelijkbare Ad-opleidingen',
-			description:
-				'In een LAdO stemmen de aangesloten Ad-opleidingen met elkaar af over een gezamenlijke profilering om tot landelijk herkenbare opleidingen te komen. Deze profilering is richtinggevend voor (aankomende) studenten, werkgevers en kwaliteitstoetsing door de NVAO.'
+			title: ladoPage.lado_card_1_title,
+			description: ladoPage.lado_card_1_body
 		},
 		{
-			title: 'Gezamenlijke afstemming op het specifieke werkveld',
-			description:
-				'Elke hogeschool heeft met haar eigen regio te maken, maar ook met landelijke werkgeversorganisaties, brancheorganisaties en beroepsverenigingen. Binnen een LAdO wordt hierover gezamenlijk afgestemd.'
+			title: ladoPage.lado_card_2_title,
+			description: ladoPage.lado_card_2_body
 		},
 		{
-			title: 'Gezamenlijke afstemming op andere (overheids)organen',
-			description:
-				"In de LAdO's is regelmatig afstemming met de NVAO, het ministerie van OCW en de Commissie Doelmatigheid Hoger Onderwijs. Opleidingen kunnen veel van elkaar leren als het gaat om accreditaties en onderwijsvernieuwingen."
+			title: ladoPage.lado_card_3_title,
+			description: ladoPage.lado_card_3_body
 		},
 		{
-			title: 'Onderlinge uitwisseling en afstemming over onderwijsuitvoering',
-			description: 'In de ontwikkeling en doorontwikkeling van Ad-opleidingen valt veel van elkaar te leren, bijvoorbeeld over niveau, toetsing, praktijkleren en digitaal onderwijsmateriaal.'
+			title: ladoPage.lado_card_4_title,
+			description: ladoPage.lado_card_4_body
 		}
-	]
+	])
 </script>
 
 <svelte:head>
@@ -31,18 +29,18 @@
 </svelte:head>
 
 <Hero
-	title="Landelijke Ad-overleggen en Ad-profielen"
-	description="Het Overlegplatform Associate degrees ondersteunt het belang van Ad-opleidingen om zich samen te positioneren en te profileren in het Nederlandse onderwijslandschap."
+	title={ladoPage.hero_heading}
+	description={ladoPage.hero_body}
 >
 	<a
 		slot="primary"
-		href="#over-lados"
-		class="button-outline-white">Lees meer</a
+		href={ladoPage.hero_primary_button_url}
+		class="button-outline-white">{ladoPage.hero_primary_button_text}</a
 	>
 	<a
 		slot="secondary"
-		href="#overzicht-lados"
-		class="button-outline-white">Bekijk overzicht</a
+		href={ladoPage.hero_secondary_button_url}
+		class="button-outline-white">{ladoPage.hero_secondary_button_text}</a
 	>
 	<img
 		class="hero-image"
@@ -57,7 +55,7 @@
 	id="over-lados"
 >
 	<div class="inner-wrapper">
-		<h2>Over LAdO's</h2>
+		<h2>{ladoPage.lado_section_heading}</h2>
 
 		<div class="card-grid">
 			{#each infoCards as card (card.title)}


### PR DESCRIPTION
## What does this change?

Resolves issue #674 

Vervangt de statische content van de Lado pagina met dynamische content vanuit de desbetreffende directus collection

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Ga naar deze branch
2. Ga naar de lado pagina
3. Ga naar de desbetreffende directus collectie 
4. Edit de collectie
5. Check of deze aangepast wordt
