### PR TITLE
676 feature content dynamisch ophalen voor publicatie pagina

### DIFF
--- a/src/lib/server/contentService.test.js
+++ b/src/lib/server/contentService.test.js
@@ -74,7 +74,8 @@ describe('ContentService property-based tests', () => {
 			'sectoralAdvisoryBoards',
 			'pageHome',
 			'pageAboutAd',
-			'pageLado'
+			'pageLado',
+			'pagePublications'
 		])
 
 		await fc.assert(

--- a/src/lib/server/strategies/directusContentStrategy.js
+++ b/src/lib/server/strategies/directusContentStrategy.js
@@ -20,7 +20,8 @@ const COLLECTIONS = {
 	sectoralAdvisoryBoards: { path: 'adconnect_sectoral_advisory_boards', key: 'id' },
 	pageHome: { path: 'adconnect_page_home', key: 'id' },
 	pageAboutAd: { path: 'adconnect_page_about_ad', key: 'id' },
-	pageLado: { path: 'adconnect_page_lado', key: 'id' }
+	pageLado: { path: 'adconnect_page_lado', key: 'id' },
+	pagePublications: { path: 'adconnect_page_publications', key: 'id' }
 }
 
 function getConfig(contentType) {

--- a/src/routes/(public)/publicaties/+page.server.js
+++ b/src/routes/(public)/publicaties/+page.server.js
@@ -1,5 +1,7 @@
 import { ContentService } from '$lib/server/contentService.js'
 
+const PUBLICATIONS_PAGE_FIELDS = 'id,hero_heading,hero_body'
+
 export async function load({ url }) {
 	// Data from Directus API
 	const fields = 'title,id,description,slug,hero_image,source_file,category.*,date'
@@ -23,12 +25,16 @@ export async function load({ url }) {
 		filter = null
 	}
 
-	const documentsResponse = await ContentService.fetchContent('documents', null, fields, filter, false)
+	const [publicationsPageResponse, documentsResponse, categoriesResponse] = await Promise.all([
+		ContentService.fetchContent('pagePublications', null, PUBLICATIONS_PAGE_FIELDS, null, false),
+		ContentService.fetchContent('documents', null, fields, filter, false),
+		ContentService.fetchContent('categories', null, null, null, false)
+	])
 
-	// Convert category data to json
-	const categoriesResponse = await ContentService.fetchContent('categories', null, null, null, false)
+	const publicationsPageItem = publicationsPageResponse.data.pagePublications?.[0]
 
 	return {
+		publicationsPage: publicationsPageItem ?? {},
 		documents: Array.from(documentsResponse.data.documents?.values?.() ?? []),
 		categories: Array.from(categoriesResponse.data.categories?.values?.() ?? []),
 		selectedCategory: category || 'alle-publicaties'

--- a/src/routes/(public)/publicaties/+page.svelte
+++ b/src/routes/(public)/publicaties/+page.svelte
@@ -11,9 +11,10 @@
 
 	// Haal data op uit page.server.js via props
 	const { data } = $props()
-	let documents = $state(data.documents)
-	let categories = $state(data.categories)
-	let selectedCategory = $state(data.selectedCategory)
+	let documents = $derived(data.documents)
+	let categories = $derived(data.categories)
+	let selectedCategory = $derived(data.selectedCategory)
+	const publicationsPage = $derived(data.publicationsPage ?? {})
 
 	// Effect om de state te synchroniseren als props veranderen
 	$effect(() => {
@@ -38,8 +39,8 @@
 </svelte:head>
 
 <Hero
-	title="Publicaties"
-	description="Hier zijn alle publicaties over Associate degrees te vinden, van onderzoeken en richtlijnen tot praktijkvoorbeelden. Blijf op de hoogte van ontwikkelingen en best practices binnen het Ad-onderwijs."
+	title={publicationsPage.hero_heading}
+	description={publicationsPage.hero_body}
 >
 	<img
 		class="hero-image"
@@ -64,8 +65,8 @@
 			<a
 				href={`?category=${categorie.title.toLowerCase()}`}
 				data-sveltekit-noscroll
-				class="button-outline-blue {selectedCategory.toLowerCase() === categorie.title.toLowerCase() ? 'active' : ''}">{categorie.title}
-				
+				class="button-outline-blue {selectedCategory.toLowerCase() === categorie.title.toLowerCase() ? 'active' : ''}"
+				>{categorie.title}
 			</a>
 		{/each}
 	</div>


### PR DESCRIPTION
## What does this change?

Resolves issue #676 

Statische content op de publicatie pagina, wordt nu dynamisch opgehaald vanuit de desbetreffende directus collectie.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Ga naar deze branch
2. Ga naar de publicaties pagina 
3. Ga naar de directus collectie
4. Edit een veld in deze collectie
5. Kijk of deze is aangepast op de pagina
