### PR TITLE
680 feature dynamische content voor nieuws pagina

### DIFF
--- a/src/lib/server/contentService.test.js
+++ b/src/lib/server/contentService.test.js
@@ -74,7 +74,8 @@ describe('ContentService property-based tests', () => {
 			'sectoralAdvisoryBoards',
 			'pageHome',
 			'pageAboutAd',
-			'pageLado'
+			'pageLado',
+			'pageNews'
 		])
 
 		await fc.assert(

--- a/src/lib/server/contentService.test.js
+++ b/src/lib/server/contentService.test.js
@@ -75,7 +75,7 @@ describe('ContentService property-based tests', () => {
 			'pageHome',
 			'pageAboutAd',
 			'pageLado',
-			'pageNews'
+			'pageNews',
 			'pagePublications'
 		])
 

--- a/src/lib/server/strategies/directusContentStrategy.js
+++ b/src/lib/server/strategies/directusContentStrategy.js
@@ -20,7 +20,8 @@ const COLLECTIONS = {
 	sectoralAdvisoryBoards: { path: 'adconnect_sectoral_advisory_boards', key: 'id' },
 	pageHome: { path: 'adconnect_page_home', key: 'id' },
 	pageAboutAd: { path: 'adconnect_page_about_ad', key: 'id' },
-	pageLado: { path: 'adconnect_page_lado', key: 'id' }
+	pageLado: { path: 'adconnect_page_lado', key: 'id' },
+	pageNews: { path: 'adconnect_page_news', key: 'id' }
 }
 
 function getConfig(contentType) {

--- a/src/routes/(public)/nieuws/+page.server.js
+++ b/src/routes/(public)/nieuws/+page.server.js
@@ -2,13 +2,18 @@
 
 import { ContentService } from '$lib/server/contentService.js'
 
+const NEWS_PAGE_FIELDS = 'id,hero_heading,hero_body'
+
 export async function load() {
-	const res = await ContentService.fetchContent('news', null, null, null, false)
+	const [newsPageResponse, res] = await Promise.all([ContentService.fetchContent('pageNews', null, NEWS_PAGE_FIELDS, null, false), ContentService.fetchContent('news', null, null, null, false)])
+
+	const newsPageItem = newsPageResponse.data.pageNews?.[0]
 	const news = Array.from(res.data.news?.values?.() ?? [])
 
 	const sortedNews = news.sort((a, b) => new Date(b.date) - new Date(a.date))
 
 	return {
+		newsPage: newsPageItem ?? {},
 		news: sortedNews,
 		latest3: sortedNews.slice(0, 3)
 	}

--- a/src/routes/(public)/nieuws/+page.svelte
+++ b/src/routes/(public)/nieuws/+page.svelte
@@ -11,22 +11,16 @@
 
 	// Haal data op uit page.server.js via props
 	const { data } = $props()
+	const newsPage = $derived(data.newsPage ?? {})
 
 	/* Pagination */
 	let currentPage = $state(1)
 
 	const itemsPerPage = 9
 
-	const totalPages = $derived(
-		Math.ceil(data.news.length / itemsPerPage)
-	)
+	const totalPages = $derived(Math.ceil(data.news.length / itemsPerPage))
 
-	const paginatedNews = $derived(
-		data.news.slice(
-			(currentPage - 1) * itemsPerPage,
-			currentPage * itemsPerPage
-		)
-	)
+	const paginatedNews = $derived(data.news.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage))
 
 	function nextPage() {
 		if (currentPage < totalPages) {
@@ -46,8 +40,8 @@
 </svelte:head>
 
 <Hero
-	title="Nieuws"
-	description="Op deze pagina vind je updates en korte verslagen van georganiseerde evenementen."
+	title={newsPage.hero_heading}
+	description={newsPage.hero_body}
 >
 	<img
 		class="hero-image"


### PR DESCRIPTION
## What does this change?

Resolves issue #680 

Vervangt de statische content met, dynamische content van de desbetreffende directus collectie.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Ga naar deze branch
2. Ga naar de publicaties pagina
3, Ga naar de directus collectie
4. Edit een veld in deze collectie
5. Kijk of deze is aangepast op de pagina
