### PR TITLE
592 608 talent award winner and section

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -124,8 +124,10 @@ export { default as RFaqSection } from './refactored/molecules/FaqSection.svelte
 export { default as RContactForm } from './refactored/molecules/ContactForm.svelte'
 export { default as RCarousel } from './refactored/molecules/Carousel.svelte'
 export { default as RTextSection } from './refactored/molecules/TextSection.svelte'
-export { default as RDetailsSection } from './refactored/organisms/DetailsSection.svelte'
+export { default as RTalentWinner } from './refactored/molecules/TalentWinner.svelte'
 
 // organisms
 export { default as RSectionHero } from './refactored/organisms/SectionHero.svelte'
 export { default as RSectionPage } from './refactored/organisms/SectionPage.svelte'
+export { default as RDetailsSection } from './refactored/organisms/DetailsSection.svelte'
+export { default as RTalentAwardSection } from './refactored/organisms/TalentAwardSection.svelte'

--- a/src/lib/refactored/molecules/CardSection.svelte
+++ b/src/lib/refactored/molecules/CardSection.svelte
@@ -24,7 +24,8 @@
 		grid-template-columns: 1fr;
 		gap: 1em;
 		width: 100%;
-		max-width: 75ch;
+		max-width: 85ch;
+		padding: 0 min(5%, 3em);
 
 		.section-header__title {
 			grid-row: 2;

--- a/src/lib/refactored/molecules/TalentWinner.svelte
+++ b/src/lib/refactored/molecules/TalentWinner.svelte
@@ -40,13 +40,12 @@
 			display: flex;
 			flex-direction: column-reverse;
 			gap: 2em;
-			align-items: flex-start;
+			align-items: start;
 
 			section {
                 display: grid;
                 gap: 1.5rem;
-                margin-bottom: 2rem;
-                margin-top: 1rem;
+                margin: 1rem 0rem 2rem 0rem
 			}
 
 			@media (min-width: 768px) {

--- a/src/lib/refactored/molecules/TalentWinner.svelte
+++ b/src/lib/refactored/molecules/TalentWinner.svelte
@@ -1,0 +1,69 @@
+<script>
+    import { RPicture } from "$lib";
+    import { DIRECTUS_URL } from '$lib/constants.js'
+    
+    const { data } =  $props()
+    const imageUrl = (id) => `${DIRECTUS_URL}/assets/${id}`
+</script>
+
+<section class="previous-winners">
+    <ul>
+        {#each data.nominations.filter((item) => item.header?.toLowerCase() === 'winnaar' && item.profile_picture) as winner (winner.id)}
+            <li>
+                <section>
+                    <h3>{winner.title}</h3>
+                    <p>{winner.excerpt}</p>
+                </section>
+                <div>
+                    <RPicture
+                        src={imageUrl(winner.profile_picture)}
+                        alt="{winner.title} met krullend haar, glimlachend naar de camera"
+                        height="200px"
+                        width="200px"
+                        style="height:auto; border-radius: 15px;"
+                    />
+                </div>   
+            </li>
+        {/each}
+    </ul>
+</section>
+
+<style>
+	.previous-winners {
+		background-color: light-dark(var(--blue-100), hsl(210, 30%, 8%));
+		padding: 2rem;
+		border-radius: 15px;
+		width: 90%;
+		max-width: 1000px;
+
+		li {
+			display: flex;
+			flex-direction: column-reverse;
+			gap: 2em;
+			align-items: flex-start;
+
+			section {
+                display: grid;
+                gap: 1.5rem;
+                margin-bottom: 2rem;
+                margin-top: 1rem;
+			}
+
+			@media (min-width: 768px) {
+				flex-direction: row-reverse;
+				align-items: center;
+			}
+		}
+	}
+
+    div {
+        display: none;
+
+        @media (min-width: 768px) {
+            display: block;
+            width: 100%;
+            max-width: 200px;
+            max-height: 200px;
+        }
+    }
+    </style>

--- a/src/lib/refactored/organisms/TalentAwardSection.svelte
+++ b/src/lib/refactored/organisms/TalentAwardSection.svelte
@@ -1,0 +1,19 @@
+<script>
+    import { RTalentWinner } from "$lib"
+    const { data } = $props()
+</script>
+
+<section>
+    <RTalentWinner { data }/>
+</section>
+
+<style>
+    section {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1.5rem;
+		margin-bottom: 2rem;
+		margin-top: 1rem;
+	}
+</style>

--- a/src/lib/refactored/organisms/TalentAwardSection.svelte
+++ b/src/lib/refactored/organisms/TalentAwardSection.svelte
@@ -1,10 +1,26 @@
 <script>
-    import { RTalentWinner } from "$lib"
+    import { RTalentWinner, Rseparator, RCardSection, RCarousel } from "$lib"
     const { data } = $props()
+
+
 </script>
 
 <section>
+    <Rseparator/>
     <RTalentWinner { data }/>
+
+    <RCardSection
+        title="Voorgaande nominaties"
+		description="Ontdek de talentvolle studenten die zijn genomineerd voor de AD Talent Award. Jaarlijks dragen hogescholen Associate degree-studenten voor die uitblinken in de praktijk, waarna een jury de
+		uiteindelijke winnaars kiest."
+    />
+    
+    <RCarousel
+        nominations
+        carouselItems={data.nominations}
+        dividerText="Voorgaande nominaties"
+    />
+
 </section>
 
 <style>
@@ -12,7 +28,7 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: 1.5rem;
+		gap: 3rem;
 		margin-bottom: 2rem;
 		margin-top: 1rem;
 	}

--- a/src/lib/refactored/organisms/TalentAwardSection.svelte
+++ b/src/lib/refactored/organisms/TalentAwardSection.svelte
@@ -6,7 +6,9 @@
 </script>
 
 <section>
-    <Rseparator/>
+    <Rseparator
+        dividerText="Voorgaande talent award winnaars"
+    />
     <RTalentWinner { data }/>
 
     <RCardSection

--- a/src/routes/(public)/talent-award/+page.svelte
+++ b/src/routes/(public)/talent-award/+page.svelte
@@ -8,7 +8,7 @@
 	const { data } = $props()
 
 	import { Hero, Divider, DividerText } from '$lib'
-	import { RCarousel, RSectionHero, Rseparator } from '$lib'
+	import { RCarousel, RSectionHero, Rseparator, RTalentAwardSection } from '$lib'
 
 	import { DIRECTUS_URL } from '$lib/constants.js'
 
@@ -141,6 +141,8 @@
 		uiteindelijke winnaars kiest.
 	</p>
 </section>
+
+<RTalentAwardSection { data }/>
 
 <RCarousel
 	nominations

--- a/src/routes/(public)/talent-award/+page.svelte
+++ b/src/routes/(public)/talent-award/+page.svelte
@@ -7,7 +7,7 @@
 
 	const { data } = $props()
 
-	import { Hero, Divider, DividerText } from '$lib'
+	import { Hero } from '$lib'
 	import { RCarousel, RSectionHero, Rseparator, RTalentAwardSection } from '$lib'
 
 	import { DIRECTUS_URL } from '$lib/constants.js'
@@ -103,86 +103,10 @@
 	</article>
 </section>
 
-<section>
-	<DividerText text="Voorgaande talent award winnaars" />
-
-	<section class="previous-winners">
-		<ul>
-			{#each data.nominations.filter((item) => item.header?.toLowerCase() === 'winnaar' && item.profile_picture) as winner (winner.id)}
-				<li>
-					<section>
-						<h3>{winner.title}</h3>
-						<p>{winner.excerpt}</p>
-					</section>
-					<img
-						src={imageUrl(winner.profile_picture)}
-						alt="{winner.title} met krullend haar, glimlachend naar de camera"
-						height="200px"
-						width="200px"
-					/>
-				</li>
-			{/each}
-		</ul>
-	</section>
-</section>
-
-<section class="nominate">
-	<img
-		class="logo"
-		aria-hidden="true"
-		src={logomobile}
-		alt="Logo"
-		width="50"
-		height="50"
-	/>
-	<h2>Voorgaande nominaties</h2>
-	<p>
-		Ontdek de talentvolle studenten die zijn genomineerd voor de AD Talent Award. Jaarlijks dragen hogescholen Associate degree-studenten voor die uitblinken in de praktijk, waarna een jury de
-		uiteindelijke winnaars kiest.
-	</p>
-</section>
-
 <RTalentAwardSection { data }/>
 
-<RCarousel
-	nominations
-	carouselItems={data.nominations}
-	dividerText="Voorgaande nominaties"
-/>
 
 <style>
-	.intro,
-	.nominate {
-		text-align: left;
-		margin: 0 auto;
-		padding: 2rem;
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-		max-width: min(900px, 92vw);
-
-		.logo {
-			display: block;
-			margin: 1rem auto;
-		}
-
-		h2 {
-			text-align: center;
-			margin-bottom: 1em;
-		}
-
-		p {
-			max-width: 500px;
-			margin: 0 auto;
-			text-align: left;
-		}
-	}
-
-	.nominate {
-		align-items: center;
-		gap: 1em;
-	}
-
 	.cards-ta {
 		container-type: inline-size;
 		container-name: cards;


### PR DESCRIPTION
## What does this change?
- The use of static written winners and nominations

Resolves issue #608 

I changed the static code for dynamic code, so that enough of the components can be used in further projects or when more winners are announced they can be shown easily instead to be hard-coded in
[livesite][(https://livesite.com](https://adconnect.dev.fdnd.nl/talent-award))

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

old:
<img width="842" height="305" alt="Screenshot 2026-06-01 161655" src="https://github.com/user-attachments/assets/861c4a0c-4da3-42ef-ba59-66ccff9f422d" />

after:
<img width="850" height="267" alt="Screenshot 2026-06-01 161308" src="https://github.com/user-attachments/assets/32dea21a-15ee-4083-b49b-8cd55b68f1fd" />


old: 
<img width="888" height="402" alt="Screenshot 2026-06-01 160939" src="https://github.com/user-attachments/assets/f0b097a7-07b3-4253-945d-69a554a21b1b" />

after:
<img width="868" height="327" alt="Screenshot 2026-06-01 161314" src="https://github.com/user-attachments/assets/0ce166cc-f083-4dcf-a176-4b970d0a8fe7" />

## Changes made
 I made the award winner without the image, because it used to take up an entire block, now the image doesn't show if the screen is smaller than 768px

old:
<img width="539" height="509" alt="Screenshot 2026-06-01 150050" src="https://github.com/user-attachments/assets/58c821f6-b5ed-4f5f-8bf1-2a982dbd704d" />

new:
<img width="393" height="212" alt="Screenshot 2026-06-01 162017" src="https://github.com/user-attachments/assets/4b00c1f8-d753-4b86-a1d0-3fbce5c9c13a" />

## How to review

- Do you understand the code and does it follow conventions?
- Is the change quite visibly different than before in ways that disrupt the flow of reading?
- Is it responsive?
