### PR TITLE
698 user story nieuws details pagesvelte refactor

### DIFF
--- a/src/lib/refactored/organisms/SectionHero.svelte
+++ b/src/lib/refactored/organisms/SectionHero.svelte
@@ -1,9 +1,12 @@
 <script>
 	import { RCardHero, RLink, RPicture } from '$lib'
-	const { sectionInfo, primaryLink, secondaryLink, picture, backgroundBlue  } = $props()
+	const { sectionInfo, primaryLink, secondaryLink, picture, backgroundBlue } = $props()
 </script>
 
-<section class="hero" class:backgroundBlue>
+<section
+	class="hero"
+	class:backgroundBlue
+>
 	<RCardHero
 		title={sectionInfo.title}
 		description={sectionInfo.description}
@@ -11,15 +14,19 @@
 		{#if primaryLink}
 			<RLink
 				href={primaryLink.href}
-				class="button-outline-white">{primaryLink.label}</RLink
-			>
+				class="button-outline-white"
+				screenReaderText={primaryLink.screenReaderText}
+				>{primaryLink.label}
+			</RLink>
 		{/if}
 
 		{#if secondaryLink}
 			<RLink
 				href={secondaryLink.href}
-				class="button-outline-blue">{secondaryLink.label}</RLink
-			>
+				class="button-outline-blue"
+				screenReaderText={secondaryLink.screenReaderText}
+				>{secondaryLink.label}
+			</RLink>
 		{/if}
 	</RCardHero>
 

--- a/src/routes/(public)/nieuws/+page.svelte
+++ b/src/routes/(public)/nieuws/+page.svelte
@@ -46,7 +46,8 @@
 		isEnhanced: true,
 		src: Nieuwshero,
 		alt: '',
-		fetchpriority: 'high'
+		fetchpriority: 'high',
+		loading: 'eager'
 	}}
 />
 

--- a/src/routes/(public)/nieuws/[uuid]/+page.svelte
+++ b/src/routes/(public)/nieuws/[uuid]/+page.svelte
@@ -1,7 +1,69 @@
 <script>
-	import { NewsDetail } from '$lib'
+	import { DIRECTUS_URL } from '$lib/constants.js'
+	import { RSectionHero } from '$lib'
 
-	const { data } = $props()
+	let { data } = $props()
 </script>
 
-<NewsDetail {data} />
+<svelte:head>
+	<title>Nieuws | Overlegplatform Associate Degrees</title>
+</svelte:head>
+
+{#each data.content as item (item.uuid)}
+	<RSectionHero
+		sectionInfo={{
+			title: item.title,
+			description: item.description
+		}}
+		primaryLink={{ label: 'Terug', href: '/nieuws', screenReaderText: 'naar nieuws pagina' }}
+		picture={{
+			src: `${DIRECTUS_URL}/assets/${item.hero}`,
+			alt: item.title,
+			fetchpriority: 'high',
+			loading: 'eager'
+		}}
+	/>
+{/each}
+
+<section class="news-detail">
+	{#each data.content as item (item.uuid)}
+		<article>
+			<h2>{item.title}</h2>
+			<p>{@html item.body}</p>
+		</article>
+	{/each}
+</section>
+
+<style>
+	.news-detail {
+		display: flex;
+		flex-direction: column;
+		gap: 2em;
+		width: 80%;
+		padding: 3em 0;
+		margin: auto;
+	}
+
+	article {
+		max-width: 600px;
+		margin: 0 auto;
+		padding: 1.5em 0;
+		h2 {
+			font-size: 1.5rem;
+			margin-bottom: 1em;
+		}
+	}
+
+	@media (min-width: 900px) {
+		.news-detail {
+			flex-direction: row;
+			align-items: flex-start;
+			justify-content: center;
+			gap: 4em;
+		}
+		article {
+			margin: 0;
+			padding: 2em 0;
+		}
+	}
+</style>

--- a/src/routes/(public)/nieuws/[uuid]/+page.svelte
+++ b/src/routes/(public)/nieuws/[uuid]/+page.svelte
@@ -27,9 +27,9 @@
 
 <section class="news-detail">
 	{#each data.content as item (item.uuid)}
-		<article>
-			<h2>{item.title}</h2>
-			<p>{@html item.body}</p>
+		<article class="news-detail__article">
+			<h2 class="news-detail__title">{item.title}</h2>
+			<div>{@html item.body}</div>
 		</article>
 	{/each}
 </section>
@@ -40,30 +40,30 @@
 		flex-direction: column;
 		gap: 2em;
 		width: 80%;
-		padding: 3em 0;
 		margin: auto;
-	}
+		padding: 3em 0;
 
-	article {
-		max-width: 600px;
-		margin: 0 auto;
-		padding: 1.5em 0;
-		h2 {
-			font-size: 1.5rem;
-			margin-bottom: 1em;
-		}
-	}
-
-	@media (min-width: 900px) {
-		.news-detail {
+		@media (min-width: 900px) {
 			flex-direction: row;
 			align-items: flex-start;
 			justify-content: center;
 			gap: 4em;
 		}
-		article {
+	}
+
+	.news-detail__article {
+		max-width: 600px;
+		margin: 0 auto;
+		padding: 1.5em 0;
+
+		@media (min-width: 900px) {
 			margin: 0;
 			padding: 2em 0;
 		}
+	}
+
+	.news-detail__title {
+		margin-bottom: 1em;
+		font-size: 1.5rem;
 	}
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #699

changes:
- on the nieuws/slug page.svelte I split the existing component into SectionHero and a section for the details page content


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images
no visual changes


## How to review

- Review the page:  `src/lib/routes/(public)/nieuws/[slug]/+page.svelte`
- Verify whether browser pages still the correct data.
