### PR TITLE
710 feature dynamisch content ophalen voor ad dag pagina

### DIFF
--- a/src/lib/molecules/location.svelte
+++ b/src/lib/molecules/location.svelte
@@ -1,37 +1,43 @@
 <script>
-  import DividerText from './DividerText.svelte'
+	import DividerText from './DividerText.svelte'
 
-  import { locationImage } from '$lib'
+	import { locationImage } from '$lib'
+
+	export let heading = ''
+	export let body = ''
 </script>
 
-<DividerText text="Locatie Ad Dag" />
+<DividerText text={heading} />
 
-<p>
-  Addag is een programma dat meestal wordt aangeboden op en van Aeres scholen. Voor meer informatie over deelname of planning kun je contact met ons
-  opnemen
-</p>
+<p>{body}</p>
 
-<img class="location-img" src={locationImage} alt="" width="600" height="300" />
+<img
+	class="location-img"
+	src={locationImage}
+	alt=""
+	width="600"
+	height="300"
+/>
 
 <style>
-  p {
-    max-width: 800px;
-    font-size: 18px;
-    padding: 2em;
-    margin: 2em auto;
-  }
+	p {
+		max-width: 800px;
+		font-size: 18px;
+		padding: 2em;
+		margin: 2em auto;
+	}
 
-  img {
-    display: block;
-    margin: auto;
-    width: 90%;
-    height: auto;
-    border-radius: 33px 33px 0 0;
-  }
+	img {
+		display: block;
+		margin: auto;
+		width: 90%;
+		height: auto;
+		border-radius: 33px 33px 0 0;
+	}
 
-  @media (min-width: 768px) {
-    img {
-      width: 60%;
-    }
-  }
+	@media (min-width: 768px) {
+		img {
+			width: 60%;
+		}
+	}
 </style>

--- a/src/lib/organisms/schedule.svelte
+++ b/src/lib/organisms/schedule.svelte
@@ -1,141 +1,154 @@
 <script>
-  import logomobile from '$lib/assets/logomobile.svg'
+	import logomobile from '$lib/assets/logomobile.svg'
+
+	export let planningHeading = ''
+	export let planningBody = ''
+	export let programHeading = ''
+	export let programBody = ''
+	export let programButtonText = ''
+	export let programButtonUrl = '#'
+	export let workshopsHeading = ''
+	export let workshopsBody = ''
+	export let workshopsButtonText = ''
+	export let workshopsButtonUrl = '#'
 </script>
 
-<section class="schedule" style="text-align: center;">
-  <section style="display: inline-block; max-width: 700px;">
-    <h2>Planning</h2>
-    <p>
-      Beleef de Landelijke Ad‑dag! De Landelijke Ad‑dag belooft een bruisende dag vol inspiratie, ontmoetingen en praktijkvoorbeelden te worden.
-      Geleid door Maikel van Duinen, radiotalent en docent, word je meegenomen in een energieke dag vol boeiende sessies, waaronder een keynote over
-      de maatschappelijke en economische impact van de Ad, inspirerende gesprekken tussen onderwijs, werkveld en studenten, de feestelijke uitreiking
-      van de Ad Talent Award, workshops en excursies om de impact van Ad‑studenten van dichtbij te ervaren, en optredens met volop gelegenheid om
-      elkaar te ontmoeten.
-    </p>
-  </section>
+<section
+	class="schedule"
+	style="text-align: center;"
+>
+	<section style="display: inline-block; max-width: 700px;">
+		<h2>{planningHeading}</h2>
+		<p>{planningBody}</p>
+	</section>
 
-  <section class="cards">
-    <article class="card">
-      <div class="wrapper-text">
-        <img class="logo" src={logomobile} alt="Logo" aria-hidden="true"/>
-        <h2>Programma</h2>
-      </div>
-      <p>
-        Programma in het kort (concept):<br />
-        <time datetime="09:30">09:30</time> <span class="visually-hidden">tot</span> – <time datetime="10:00">10:00</time> | Inloop met koffie/thee<br />
-        <time datetime="10:00">10:00</time> <span class="visually-hidden">tot</span> – <time datetime="13:00">13:00</time> | Opening, keynote, gesprekken en Ad Talent Award<br />
-        <time datetime="13:00">13:00</time> <span class="visually-hidden">tot</span> – <time datetime="13:45">10:00</time> | Lunch<br />
-        <time datetime="13:45">13:45</time> <span class="visually-hidden">tot</span> – <time datetime="15:30">15:30</time> | Workshops en excursies<br />
-        <time datetime="15:30">15:30</time> <span class="visually-hidden">tot</span> – <time datetime="17:00">17:00</time> | Borrel & ontmoeting<br />
-      </p>
-      <a class="button-outline-blue" href="#">Bekijk Programma </a>
-    </article>
+	<section class="cards">
+		<article class="card">
+			<div class="wrapper-text">
+				<img
+					class="logo"
+					src={logomobile}
+					alt="Logo"
+					aria-hidden="true"
+				/>
+				<h2>{programHeading}</h2>
+			</div>
+			<p>{programBody}</p>
+			<a
+				class="button-outline-blue"
+				href={programButtonUrl}>{programButtonText}</a
+			>
+		</article>
 
-    <article class="card">
-      <div class="wrapper-text">
-        <img class="logo" src={logomobile} alt="Logo" aria-hidden="true"/>
-        <h2>Workshops</h2>
-      </div>
-      <p>
-        Tijdens de Landelijke Ad‑dag worden verschillende workshops georganiseerd waarin deelnemers samen leren, ervaringen delen en praktische
-        handvatten krijgen op thema’s zoals diversiteit, professionalisering, inzet van technologie binnen Ad‑onderwijs, loopbaanontwikkeling,
-        duurzaamheid en samenwerking met werkveld en onderwijs. De precieze workshoptitels en inhoud worden jaarlijks aangepast en zijn onderdeel van
-        het programma
-      </p>
-      <a class="button-outline-blue" href="link">Bekijk Workshops </a>
-    </article>
-  </section>
+		<article class="card">
+			<div class="wrapper-text">
+				<img
+					class="logo"
+					src={logomobile}
+					alt="Logo"
+					aria-hidden="true"
+				/>
+				<h2>{workshopsHeading}</h2>
+			</div>
+			<p>{workshopsBody}</p>
+			<a
+				class="button-outline-blue"
+				href={workshopsButtonUrl}>{workshopsButtonText}</a
+			>
+		</article>
+	</section>
 </section>
 
 <style>
-  .schedule {
-    background-color: light-dark(var(--primary-blue), var(--blue-800));
-    color: var(--text-white);
-    padding: 2em;
-    margin: auto;
-    text-align: center;
-    box-shadow: 0 0 0 100vmax var(--primary-blue);
-    clip-path: inset(0 -100vmax);
+	.schedule {
+		background-color: light-dark(var(--primary-blue), var(--blue-800));
+		color: var(--text-white);
+		padding: 2em;
+		margin: auto;
+		text-align: center;
+		box-shadow: 0 0 0 100vmax var(--primary-blue);
+		clip-path: inset(0 -100vmax);
 
-    h2 {
-      margin-top: 1em;
-      color: var(--text-white);
-      margin-bottom: 1em;
-    }
+		h2 {
+			margin-top: 1em;
+			color: var(--text-white);
+			margin-bottom: 1em;
+		}
 
-    p {
-      text-align: left;
-    }
-  }
+		p {
+			text-align: left;
+			white-space: pre-line;
+		}
+	}
 
-  .cards {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: repeat(4, auto);
-    margin-top: 5em;
-    gap: 1em;
-    margin-bottom: 2em;
+	.cards {
+		display: grid;
+		grid-template-columns: 1fr;
+		grid-template-rows: repeat(4, auto);
+		margin-top: 5em;
+		gap: 1em;
+		margin-bottom: 2em;
 
-    article {
-      border: 1px solid #cccccc;
-      border-radius: 1em;
-      padding: 2em;
-      transition: 0.2s ease-in-out;
-      display: flex;
-      flex-direction: column;
-      gap: 1em;
-      background-color: light-dark(var(--text-white), hsl(210, 30%, 8%));
-      text-align: center;
-      margin: 0 auto;
+		article {
+			border: 1px solid #cccccc;
+			border-radius: 1em;
+			padding: 2em;
+			transition: 0.2s ease-in-out;
+			display: flex;
+			flex-direction: column;
+			gap: 1em;
+			background-color: light-dark(var(--text-white), hsl(210, 30%, 8%));
+			text-align: center;
+			margin: 0 auto;
 
-      p {
-        max-width: 500px;
-      }
+			p {
+				max-width: 500px;
+			}
 
-      &:hover {
-        border: 1px solid #00408d;
-        box-shadow: 0 3px 10px rgba(141, 141, 141, 0.2);
-        translate: 0 -1%;
-        transition: 0.2s ease-in-out;
-      }
-    }
+			&:hover {
+				border: 1px solid #00408d;
+				box-shadow: 0 3px 10px rgba(141, 141, 141, 0.2);
+				translate: 0 -1%;
+				transition: 0.2s ease-in-out;
+			}
+		}
 
-    h2 {
-      color: var(--primary-blue);
-    }
-  }
+		h2 {
+			color: var(--primary-blue);
+		}
+	}
 
-  .card {
-    display: grid;
-    grid-template-rows: subgrid;
-    grid-row: span 4;
-    border: 1px solid var(--text-white);
-    background-color: var(--text-white);
-    color: light-dark(var(--primary-blue), var(--text-white));
-    border-radius: 24px;
-    padding: 2em;
+	.card {
+		display: grid;
+		grid-template-rows: subgrid;
+		grid-row: span 4;
+		border: 1px solid var(--text-white);
+		background-color: var(--text-white);
+		color: light-dark(var(--primary-blue), var(--text-white));
+		border-radius: 24px;
+		padding: 2em;
 
-    .logo {
-      margin: 0;
-      text-align: left;
-      float: left;
-    }
-    h2 {
-      margin-top: 0;
-      margin-bottom: 0.5em;
-      right: 1em;
-      position: relative;
-    }
-  }
+		.logo {
+			margin: 0;
+			text-align: left;
+			float: left;
+		}
+		h2 {
+			margin-top: 0;
+			margin-bottom: 0.5em;
+			right: 1em;
+			position: relative;
+		}
+	}
 
-  a {
-    margin-top: 1em;
-    align-self: center;
-  }
-  @media (min-width: 1024px) {
-    .cards {
-      grid-template-columns: repeat(2, 1fr);
-      gap: 0.5em;
-    }
-  }
+	a {
+		margin-top: 1em;
+		align-self: center;
+	}
+	@media (min-width: 1024px) {
+		.cards {
+			grid-template-columns: repeat(2, 1fr);
+			gap: 0.5em;
+		}
+	}
 </style>

--- a/src/lib/server/contentService.test.js
+++ b/src/lib/server/contentService.test.js
@@ -74,7 +74,8 @@ describe('ContentService property-based tests', () => {
 			'sectoralAdvisoryBoards',
 			'pageHome',
 			'pageAboutAd',
-			'pageLado'
+			'pageLado',
+			'pageAdDay'
 		])
 
 		await fc.assert(

--- a/src/lib/server/strategies/directusContentStrategy.js
+++ b/src/lib/server/strategies/directusContentStrategy.js
@@ -20,7 +20,8 @@ const COLLECTIONS = {
 	sectoralAdvisoryBoards: { path: 'adconnect_sectoral_advisory_boards', key: 'id' },
 	pageHome: { path: 'adconnect_page_home', key: 'id' },
 	pageAboutAd: { path: 'adconnect_page_about_ad', key: 'id' },
-	pageLado: { path: 'adconnect_page_lado', key: 'id' }
+	pageLado: { path: 'adconnect_page_lado', key: 'id' },
+	pageAdDay: { path: 'adconnect_page_ad_day', key: 'id' }
 }
 
 function getConfig(contentType) {

--- a/src/routes/(public)/ad-dag/+page.server.js
+++ b/src/routes/(public)/ad-dag/+page.server.js
@@ -1,0 +1,39 @@
+import { ContentService } from '$lib/server/contentService.js'
+
+const AD_DAY_PAGE_FIELDS = [
+	'id',
+	'hero_heading',
+	'hero_body',
+	'about_heading',
+	'about_body',
+	'faq_heading',
+	'faq_1_heading',
+	'faq_1_body',
+	'faq_2_heading',
+	'faq_2_body',
+	'faq_3_heading',
+	'faq_3_body',
+	'faq_4_heading',
+	'faq_4_body',
+	'planning_heading',
+	'planning_body',
+	'program_heading',
+	'program_body',
+	'program_button_text',
+	'program_button_url',
+	'workshops_heading',
+	'workshops_body',
+	'workshops_button_text',
+	'workshops_button_url',
+	'location_heading',
+	'location_body'
+].join(',')
+
+export async function load() {
+	const adDayPageResponse = await ContentService.fetchContent('pageAdDay', null, AD_DAY_PAGE_FIELDS, null, false)
+	const adDayPageItem = adDayPageResponse.data.pageAdDay?.[0]
+
+	return {
+		adDayPage: adDayPageItem ?? {}
+	}
+}

--- a/src/routes/(public)/ad-dag/+page.svelte
+++ b/src/routes/(public)/ad-dag/+page.svelte
@@ -5,21 +5,18 @@
 	import addag3 from '$lib/assets/addag-3.webp'
 
 	import { MultipleFaq, SingleFaq, Hero, Addag, Location, Schedule } from '$lib'
+
+	const { data } = $props()
+	const adDayPage = $derived(data.adDayPage ?? {})
 </script>
 
 <svelte:head>
 	<title>Ad dag | Overlegplatform Associate Degrees</title>
 </svelte:head>
 
-
 <Hero
-	title="Ad Dag "
-	description="De landelijks Ad-dag 2025 is hét moment waarop studenten,
-	docenten en professionals uit het Ad-onderwijs samenkomen.Ontdek, leer en
-	inspireer elkaar tijdens een dag vol sprekers, workshops en ontmoetingen.
-	Ervaar hoe de Ad-professional als veranderaar impact maakt en vier samen de
-	uitreiking van de Ad Talent Awards. Meld je aan voor de komende ad dag of
-	blijf op de hoogte "
+	title={adDayPage.hero_heading}
+	description={adDayPage.hero_body}
 >
 	<img
 		class="hero-image"
@@ -31,12 +28,8 @@
 
 <section class="intro">
 	<article>
-		<h2>Wat is de landelijke Ad-dag?</h2>
-		<p>
-			De Landelijke Ad-dag is het jaarlijkse moment waarop Associate degree (Ad)-onderwijs centraal staat. Studenten, docenten, coördinatoren, beleidsmakers en het werkveld komen samen om kennis te
-			delen, inspiratie op te doen en elkaar te ontmoeten. Verwacht een mix van plenaire sessies, panelgesprekken, workshops en praktijkvoorbeelden waarin je ziet wat niveau 5 toevoegt aan het hbo
-			en aan organisaties. Het is tegelijk een showcase en werkdag: je viert wat er al gebeurt én je neemt concrete ideeën mee om morgen toe te passen.
-		</p>
+		<h2>{adDayPage.about_heading}</h2>
+		<p>{adDayPage.about_body}</p>
 	</article>
 	<img
 		src={addag3}
@@ -51,28 +44,28 @@
 		src={logomobile}
 		alt=""
 	/>
-	<h2>Alles wat je wilt weten over de Ad-dag?</h2>
+	<h2>{adDayPage.faq_heading}</h2>
 
 	<MultipleFaq>
 		<SingleFaq
 			open={true}
-			question="Voor wie is de Ad-dag bedoeld?"
-			answer="De Landelijke Ad‑dag is bedoeld voor iedereen die betrokken is bij of interesse heeft in Associate degree‑onderwijs in Nederland. Dit omvat studenten, docenten, onderwijsprofessionals, werkveldpartners, onderwijsinstellingen en andere geïnteresseerden die willen zien hoe Ad‑onderwijs impact maakt op onderwijs en arbeidsmarkt."
+			question={adDayPage.faq_1_heading}
+			answer={adDayPage.faq_1_body}
 		/>
 
 		<SingleFaq
-			question="Wie komen er naar de Ad-dag?"
-			answer="De Landelijke Ad‑dag brengt alle betrokkenen van Associate degree‑onderwijs samen, zoals studenten en alumni, docenten en onderwijsprofessionals, werkveldpartners en werkgevers, en beleidsmakers en onderwijsorganisaties die kennis en ervaringen willen uitwisselen. Het is een dag vol inspiratie, netwerken en het delen van de impact van Ad‑onderwijs."
+			question={adDayPage.faq_2_heading}
+			answer={adDayPage.faq_2_body}
 		/>
 
 		<SingleFaq
-			question="Waarom zou ik naar de Ad-dag moeten gaan?"
-			answer="De Landelijke Ad‑dag is dé gelegenheid om inspiratie op te doen, te netwerken met studenten, docenten, werkveldpartners en beleidsmakers, en te ontdekken hoe Associate degree‑onderwijs impact maakt op zowel onderwijs als arbeidsmarkt. Je leert over innovatie, doorstroommogelijkheden en krijgt inzichten die je direct kunt toepassen in je studie, werk of organisatie."
+			question={adDayPage.faq_3_heading}
+			answer={adDayPage.faq_3_body}
 		/>
 
 		<SingleFaq
-			question="Wanneer en waar vindt de Ad-dag plaats?"
-			answer="De Landelijke Ad‑dag 2026 vindt plaats op vrijdag 17 april 2026 in Groningen, georganiseerd bij de Hanzehogeschool."
+			question={adDayPage.faq_4_heading}
+			answer={adDayPage.faq_4_body}
 		/>
 	</MultipleFaq>
 
@@ -84,9 +77,22 @@
 		height="300"
 	/>
 </section>
-<Schedule />
-<Location />
-
+<Schedule
+	planningHeading={adDayPage.planning_heading}
+	planningBody={adDayPage.planning_body}
+	programHeading={adDayPage.program_heading}
+	programBody={adDayPage.program_body}
+	programButtonText={adDayPage.program_button_text}
+	programButtonUrl={adDayPage.program_button_url}
+	workshopsHeading={adDayPage.workshops_heading}
+	workshopsBody={adDayPage.workshops_body}
+	workshopsButtonText={adDayPage.workshops_button_text}
+	workshopsButtonUrl={adDayPage.workshops_button_url}
+/>
+<Location
+	heading={adDayPage.location_heading}
+	body={adDayPage.location_body}
+/>
 
 <style>
 	.intro {


### PR DESCRIPTION
## What does this change?

Resolves issue #710 

Vervangt de statische content met, dynamische content vanuit de desbetreffende directus collectie.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Ga naar deze branch
2. Ga naar de ad-dag pagina
3. Ga naar de directus collectie en edit deze
4. Kijk op de pagina of deze is aangepast
