### PR TITLE
611 error section

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -85,6 +85,8 @@
 		}
 
 		ul {
+			list-style-position: inside;
+			
 			display: flex;
 			flex-direction: column;
 			align-items: center;
@@ -108,7 +110,7 @@
 	} 
 
 	.image_container {
-		width: 400px;
+		max-width: 400px;
 		align-self: center;
 	}
 </style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -3,6 +3,7 @@
 
 	// Import Atomic Design
 	import { NavPros, TopNav, bird, Footer } from '$lib'
+	const { item } = $props()
 </script>
 
 <svelte:head>
@@ -108,5 +109,5 @@
 				color: var(--primary-orange);
 			}
 		}
-	}
+	} 
 </style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state'
 
 	// Import Atomic Design
-	import { NavPros, TopNav, bird, Footer } from '$lib'
+	import { NavPros, TopNav, bird, Footer, RPicture } from '$lib'
 	const { item } = $props()
 </script>
 
@@ -19,10 +19,11 @@
 <div
 	class="wrapper-error"
 	id="main"
->
+>	
+	
 	<section>
-		<h1>Oeps {page.status} error</h1>
-		<p>De pagina die je probeert te bereiken lijkt niet te bestaan. Navigeer naar een van onze werkende pagina's hieronder.</p>
+		<h1 class="error-section_header">Oeps {page.status} error</h1>
+		<p class="error-section_description">De pagina die je probeert te bereiken lijkt niet te bestaan. Navigeer naar een van onze werkende pagina's hieronder.</p>
 
 		<ul>
 			<li><a href="/over-ad">Over Ad's</a></li>
@@ -35,15 +36,21 @@
 		</ul>
 	</section>
 
-	<img
-		src={bird}
-		alt="Een vogel in een pak met een bril die een boek vasthoud"
-	/>
+    <div class="image_container">
+        <RPicture
+            isEnhanced
+            src={bird}
+            style="height: auto; overflow:hidden;"
+            width="100"
+        />
+    </div>
+
 </div>
 
 <Footer />
 
 <style>
+	
 	.wrapper-error {
 		display: flex;
 		flex-direction: column-reverse;
@@ -53,22 +60,13 @@
 		max-width: 1400px;
 		padding: 3em 0;
 		padding-top: 9em;
-
+		
 		@media (min-width: 768px) {
 			padding: 5em 0;
 			padding-top: 10em;
 			flex-direction: row-reverse;
 		}
-
-		img {
-			width: 20em;
-			align-self: center;
-
-			@media (min-width: 768px) {
-				width: 25em;
-			}
-		}
-
+		
 		section {
 			display: flex;
 			flex-direction: column;
@@ -76,8 +74,8 @@
 			margin: auto;
 		}
 
-		h1,
-		p {
+		.error-section_header,
+		.error-section_description {
 			text-align: center;
 
 			@media (min-width: 768px) {
@@ -88,26 +86,28 @@
 
 		ul {
 			display: flex;
-			flex-direction: row;
+			flex-direction: column;
+			align-items: center;
 			flex-wrap: wrap;
-			gap: 0.5em 1.5em;
-			justify-content: center;
-
-			@media (min-width: 768px) {
+			
+			@media (min-width: 500px) {
 				justify-content: left;
+				flex-direction: row;
+				gap: 0.5em 1.5em;
 			}
 		}
 
-		li:first-of-type {
-			list-style-type: none;
-		}
-
 		a {
-			color: var(--blue-800);
+			color: light-dark(var(----text-darkblue), var(--text-white));
 
 			&:hover {
 				color: var(--primary-orange);
 			}
 		}
 	} 
+
+	.image_container {
+		width: 400px;
+		align-self: center;
+	}
 </style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -89,6 +89,7 @@
 			flex-direction: column;
 			align-items: center;
 			flex-wrap: wrap;
+			gap: 1.5em;
 			
 			@media (min-width: 500px) {
 				justify-content: left;


### PR DESCRIPTION
## What does this change?
Changes the error section page so that it is now readable

Resolves issue #688 

In this PR I made the error section in the style it needs to be used. We saw in the live versions the links aren't readable so I fixed that and the position of the links

[Error page](https://adconnect.dev.fdnd.nl/ad-da)

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

old fault with links being readable:
<img width="357" height="130" alt="Screenshot 2026-06-03 144357" src="https://github.com/user-attachments/assets/59af2937-e236-4e72-8874-8fe207951855" />


old layout:
<img width="369" height="352" alt="Screenshot 2026-06-03 144412" src="https://github.com/user-attachments/assets/1ac5e202-8cc2-4c68-a4c2-2346d560a75b" />
>

new layout:
<img width="379" height="402" alt="Screenshot 2026-06-03 144407" src="https://github.com/user-attachments/assets/7dbfe936-d9d5-41c1-a25b-60e968c68802" />


## How to review

- See if the content aligns neatly with the page
- Does it hold up to our conventions?