### PR TITLE
fix: light annd darkmode colors

### DIFF
--- a/src/lib/organisms/LadosOverview.svelte
+++ b/src/lib/organisms/LadosOverview.svelte
@@ -118,7 +118,7 @@
 
 <style>
 	.lados-overview {
-		background: light-dark(var(--text-white), var(--blue-800));
+		background-color: var(--_main-background);
 		color: light-dark(var(--blue-800), var(--text-white));
 		padding: 3em 5% 5em;
 	}

--- a/src/lib/refactored/molecules/CardHero.svelte
+++ b/src/lib/refactored/molecules/CardHero.svelte
@@ -19,6 +19,8 @@
 
 <style>
 	.page-header {
+		--_color: white;
+
 		display: flex;
 		flex-direction: column;
 		align-self: end;
@@ -26,6 +28,10 @@
 		width: 100%;
 		max-width: 75ch;
 		margin-top: 1em;
+	}
+
+	.page-header, .page-header__title {
+		color: var(--_color);
 	}
 
 	.page-header__buttons {

--- a/src/lib/refactored/molecules/CardSection.svelte
+++ b/src/lib/refactored/molecules/CardSection.svelte
@@ -5,7 +5,12 @@
 </script>
 
 <article class="section-header">
-	<h2 class="section-header__title" class:centered>{title}</h2>
+	<h2
+		class="section-header__title"
+		class:centered
+	>
+		{title}
+	</h2>
 	<p class="section-header__description">{description}</p>
 
 	<div class:centered>
@@ -31,10 +36,15 @@
 
 		.section-header__title {
 			grid-row: 2;
+			color: var(--_main-color);
+			/* color: contrast-color(var(--_main-color)); */
 		}
 
 		.section-header__description {
 			grid-row: 3;
+			/* contrast-color() is not supported, that why it overwritten */
+			color: var(--_main-color);
+			/* color: contrast-color(var(--_main-color)); */
 		}
 	}
 

--- a/src/lib/refactored/molecules/Carousel.svelte
+++ b/src/lib/refactored/molecules/Carousel.svelte
@@ -126,7 +126,7 @@
 
 		@media (min-width: 768px) {
 			gap: 3em;
-			padding: 0 0 5em 0;
+			padding: 2.5em 0 2.5em 0;
 		}
 	}
 

--- a/src/lib/refactored/molecules/FilterButtons.svelte
+++ b/src/lib/refactored/molecules/FilterButtons.svelte
@@ -119,6 +119,7 @@
 
 			&:has(input:checked) {
 				background-color: var(--primary-blue);
+				color: white;
 			}
 		}
 	}

--- a/src/lib/refactored/organisms/AboutOverAD.svelte
+++ b/src/lib/refactored/organisms/AboutOverAD.svelte
@@ -42,7 +42,7 @@
 		max-width: 1400px;
 		margin: auto;
 		padding: 3em 5%;
-		background-color: light-dark(var(--text-white), var(--blue-800));
+		background-color: var(--_main-background);
 
 		@media (min-width: 1024px) {
 			gap: 4em;

--- a/src/lib/refactored/organisms/SectionHero.svelte
+++ b/src/lib/refactored/organisms/SectionHero.svelte
@@ -68,7 +68,7 @@
 	}
 
 	.backgroundBlue {
-		--_background: light-dark(var(--text-white), var(--blue-800));
+		--_background: light-dark(var(--primary-blue), var(--blue-800));
 	}
 
 	.hero__media {

--- a/src/lib/refactored/organisms/SectionPage.svelte
+++ b/src/lib/refactored/organisms/SectionPage.svelte
@@ -68,6 +68,11 @@
 
 	.media-section--background-black {
 		--_background: light-dark(var(--primary-blue), hsl(210, 30%, 8%));
+		/* overwrite main-color to white here, because the component CardSection uses it for text color,
+		but in this situation (without the overwrite) the dark mode will have blue background with black text,
+		which is not enough contrast */
+		--_main-color: white;
+
 	}
 
 	.media-section--vertical {

--- a/src/lib/refactored/organisms/SectionThemes.svelte
+++ b/src/lib/refactored/organisms/SectionThemes.svelte
@@ -28,6 +28,7 @@
 <style>
 	.themes {
 		--_background: light-dark(var(--primary-blue), hsl(210, 30%, 8%));
+		--_color: white;
 
 		display: flex;
 		flex-direction: column;
@@ -48,6 +49,11 @@
 
 	.themes__title {
 		text-align: center;
+		color: var(--_color);
+	}
+
+	.themes__description {
+		color: var(--_color);
 	}
 
 	.themes__list {

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -49,7 +49,12 @@
 	}
 
 	main {
+		--_main-background: light-dark(var(--blue-150), var(--blue-800));
+		--_main-color: light-dark(black, white);
+
 		margin: 7.9em 0 0 0;
+		background-color: var(--_main-background);
+		color: var(--_main-color);
 	}
 
 	.skip-link {

--- a/src/routes/(public)/lados-en-ad-profielen/+page.svelte
+++ b/src/routes/(public)/lados-en-ad-profielen/+page.svelte
@@ -65,7 +65,7 @@
 
 <style>
 	.lado-info {
-		background: light-dark(var(--text-white), var(--blue-800));
+		background-color: var(--_main-background);
 		padding: 3em 5%;
 	}
 	.inner-wrapper {


### PR DESCRIPTION
## What does this change?

This PR introduces custom properties in the main stylesheet for controlling the background color and text color in light mode.

This was a quick fix. I noticed the issue just before the sprint review, so the solution is functional but should be further refined and developed in a future iteration.

For now, this fixes the light mode colors. The remaining work is to apply these custom properties consistently throughout the application so that both text and background colors are controlled by them and update correctly when the theme changes.